### PR TITLE
Feat/cardhandgun

### DIFF
--- a/game.server/src/card/card.hand_gun.effect.ts
+++ b/game.server/src/card/card.hand_gun.effect.ts
@@ -4,9 +4,40 @@ import { getUserFromRoom, updateCharacterFromRoom } from "../utils/redis.util.js
 const cardHandGunEffect = async (roomId:number, userId:string, targetUserId:string) =>{
     const user = await getUserFromRoom(roomId, userId);
     const target = await getUserFromRoom(roomId, targetUserId);
+    
     // 유효성 검증
-    if (!user || !target || !target.character) return; 
-
+    if (!user || !user.character) return; 
+    
+    // 핸드건 카드 효과: 무기 장착
+    // targetUserId가 있으면 해당 플레이어, 없으면 자신에게 무기 장착
+    const targetUser = targetUserId && target ? target : user;
+    
+    // 대상 유저의 캐릭터가 존재하는지 확인
+    if (!targetUser.character) {
+        console.warn(`[핸드건] 대상 유저 ${targetUser.nickname}의 캐릭터 정보가 없습니다.`);
+        return;
+    }
+    
+    // 이미 핸드건을 장착하고 있는지 확인
+    if (targetUser.character.weapon === 14) { // 14 = HAND_GUN
+        console.log(`[핸드건] ${targetUser.nickname}은 이미 핸드건을 장착하고 있습니다.`);
+        return;
+    }
+    
+    // 이전 무기 정보 저장
+    const previousWeapon = targetUser.character.weapon;
+    
+    // 핸드건 장착 (무기 ID: 14)
+    targetUser.character.weapon = 14;
+    
+    // Redis에 업데이트된 캐릭터 정보 저장
+    try {
+        await updateCharacterFromRoom(roomId, targetUser.id, targetUser.character);
+        console.log(`[핸드건] ${targetUser.nickname}이 핸드건을 장착했습니다. (이전 무기: ${previousWeapon})`);
+    } catch (error) {
+        console.error(`[핸드건] Redis 업데이트 실패:`, error);
+        // 에러가 발생해도 함수는 정상적으로 완료됨
+    }
 }
 
 

--- a/game.server/src/card/card.hand_gun.effect.ts
+++ b/game.server/src/card/card.hand_gun.effect.ts
@@ -3,37 +3,23 @@ import { getUserFromRoom, updateCharacterFromRoom } from "../utils/redis.util.js
 
 const cardHandGunEffect = async (roomId:number, userId:string, targetUserId:string) =>{
     const user = await getUserFromRoom(roomId, userId);
-    const target = await getUserFromRoom(roomId, targetUserId);
     
     // 유효성 검증
     if (!user || !user.character) return; 
     
-    // 핸드건 카드 효과: 무기 장착
-    // targetUserId가 있으면 해당 플레이어, 없으면 자신에게 무기 장착
-    const targetUser = targetUserId && target ? target : user;
+    // 핸드건 카드 효과: 하루에 사용할 수 있는 빵야!가 두 개로 증가
+    // 무기 카드이므로 자신에게만 적용 (targetUserId 무시)
     
-    // 대상 유저의 캐릭터가 존재하는지 확인
-    if (!targetUser.character) {
-        console.warn(`[핸드건] 대상 유저 ${targetUser.nickname}의 캐릭터 정보가 없습니다.`);
+    if (user.character.bbangCount >= 2) {
         return;
     }
     
-    // 이미 핸드건을 장착하고 있는지 확인
-    if (targetUser.character.weapon === 14) { // 14 = HAND_GUN
-        console.log(`[핸드건] ${targetUser.nickname}은 이미 핸드건을 장착하고 있습니다.`);
-        return;
-    }
-    
-    // 이전 무기 정보 저장
-    const previousWeapon = targetUser.character.weapon;
-    
-    // 핸드건 장착 (무기 ID: 14)
-    targetUser.character.weapon = 14;
+    // 빵야! 횟수를 2개로 증가 (기본 1 → 2)
+    user.character.bbangCount = 2;
     
     // Redis에 업데이트된 캐릭터 정보 저장
     try {
-        await updateCharacterFromRoom(roomId, targetUser.id, targetUser.character);
-        console.log(`[핸드건] ${targetUser.nickname}이 핸드건을 장착했습니다. (이전 무기: ${previousWeapon})`);
+        await updateCharacterFromRoom(roomId, user.id, user.character);
     } catch (error) {
         console.error(`[핸드건] Redis 업데이트 실패:`, error);
         // 에러가 발생해도 함수는 정상적으로 완료됨

--- a/game.server/src/card/test/card.hand_gun.effect.test.ts
+++ b/game.server/src/card/test/card.hand_gun.effect.test.ts
@@ -1,0 +1,229 @@
+import cardHandGunEffect from '../card.hand_gun.effect';
+import { getUserFromRoom, updateCharacterFromRoom } from '../../utils/redis.util';
+import { CharacterType, RoleType } from '../../generated/common/enums';
+
+// Mock 설정
+jest.mock('../../utils/redis.util', () => ({
+  getUserFromRoom: jest.fn(),
+  updateCharacterFromRoom: jest.fn(),
+}));
+
+const mockGetUserFromRoom = getUserFromRoom as jest.MockedFunction<typeof getUserFromRoom>;
+const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.MockedFunction<typeof updateCharacterFromRoom>;
+
+describe('cardHandGunEffect', () => {
+  const roomId = 1;
+  const userId = 'user1';
+  const targetUserId = 'user2';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('유효성 검증', () => {
+    it('사용자가 없으면 함수가 종료된다', async () => {
+      mockGetUserFromRoom.mockResolvedValue(null);
+
+      await cardHandGunEffect(roomId, userId, targetUserId);
+
+      expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
+      expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+    });
+
+    it('사용자의 캐릭터가 없으면 함수가 종료된다', async () => {
+      const user = { id: userId, nickname: 'testUser' };
+      mockGetUserFromRoom.mockResolvedValue(user);
+
+      await cardHandGunEffect(roomId, userId, targetUserId);
+
+      expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
+      expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+    });
+
+    it('대상 사용자의 캐릭터가 없으면 경고 로그를 출력하고 함수가 종료된다', async () => {
+      const user = {
+        id: userId,
+        nickname: 'user1',
+        character: {
+          characterType: CharacterType.RED,
+          roleType: RoleType.TARGET,
+          hp: 3,
+          weapon: 0,
+          equips: [],
+          debuffs: [],
+          handCards: [],
+          bbangCount: 0,
+          handCardsCount: 0,
+        },
+      };
+      const target = { id: targetUserId, nickname: 'user2' };
+
+      mockGetUserFromRoom
+        .mockResolvedValueOnce(user)
+        .mockResolvedValueOnce(target);
+
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      await cardHandGunEffect(roomId, userId, targetUserId);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[핸드건] 대상 유저 user2의 캐릭터 정보가 없습니다.'
+      );
+      expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('무기 장착 로직', () => {
+    const createMockCharacter = (weapon: number) => ({
+      characterType: CharacterType.RED,
+      roleType: RoleType.TARGET,
+      hp: 3,
+      weapon,
+      equips: [],
+      debuffs: [],
+      handCards: [],
+      bbangCount: 0,
+      handCardsCount: 0,
+    });
+
+    it('자신에게 핸드건을 장착한다 (targetUserId가 빈 문자열인 경우)', async () => {
+      const user = {
+        id: userId,
+        nickname: 'user1',
+        character: createMockCharacter(0), // 무기 없음
+      };
+
+      mockGetUserFromRoom.mockResolvedValue(user);
+
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      await cardHandGunEffect(roomId, userId, '');
+
+      expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
+        ...user.character,
+        weapon: 14, // 핸드건 ID
+      });
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[핸드건] user1이 핸드건을 장착했습니다. (이전 무기: 0)'
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('다른 플레이어에게 핸드건을 장착한다', async () => {
+      const user = {
+        id: userId,
+        nickname: 'user1',
+        character: createMockCharacter(0),
+      };
+      const target = {
+        id: targetUserId,
+        nickname: 'user2',
+        character: createMockCharacter(1), // 다른 무기 장착 중
+      };
+
+      mockGetUserFromRoom
+        .mockResolvedValueOnce(user)
+        .mockResolvedValueOnce(target);
+
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      await cardHandGunEffect(roomId, userId, targetUserId);
+
+      expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, targetUserId, {
+        ...target.character,
+        weapon: 14, // 핸드건 ID
+      });
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[핸드건] user2이 핸드건을 장착했습니다. (이전 무기: 1)'
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('이미 핸드건을 장착한 경우 장착하지 않는다', async () => {
+      const user = {
+        id: userId,
+        nickname: 'user1',
+        character: createMockCharacter(14), // 이미 핸드건 장착
+      };
+
+      mockGetUserFromRoom.mockResolvedValue(user);
+
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      await cardHandGunEffect(roomId, userId, '');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[핸드건] user1은 이미 핸드건을 장착하고 있습니다.'
+      );
+      expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('다른 무기를 핸드건으로 교체한다', async () => {
+      const user = {
+        id: userId,
+        nickname: 'user1',
+        character: createMockCharacter(13), // 스나이퍼 건 장착 중
+      };
+
+      mockGetUserFromRoom.mockResolvedValue(user);
+
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      await cardHandGunEffect(roomId, userId, '');
+
+      expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
+        ...user.character,
+        weapon: 14, // 핸드건으로 교체
+      });
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[핸드건] user1이 핸드건을 장착했습니다. (이전 무기: 13)'
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('에러 처리', () => {
+    it('updateCharacterFromRoom에서 에러가 발생해도 함수가 정상적으로 처리된다', async () => {
+      const user = {
+        id: userId,
+        nickname: 'user1',
+        character: {
+          characterType: CharacterType.RED,
+          roleType: RoleType.TARGET,
+          hp: 3,
+          weapon: 0,
+          equips: [],
+          debuffs: [],
+          handCards: [],
+          bbangCount: 0,
+          handCardsCount: 0,
+        },
+      };
+
+      mockGetUserFromRoom.mockResolvedValue(user);
+      mockUpdateCharacterFromRoom.mockRejectedValue(new Error('Redis error'));
+
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      // 에러가 발생해도 함수가 정상적으로 처리되는지 확인
+      await expect(cardHandGunEffect(roomId, userId, '')).resolves.not.toThrow();
+
+      // 에러 로그가 출력되는지 확인
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[핸드건] Redis 업데이트 실패:',
+        expect.any(Error)
+      );
+
+      consoleSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## 제목
핸드건 이펙트 구현
## 내용
- bbangCount를 2로 고정 설정 
- bbangCount >= 2인 경우 중복 적용 방지
- 로그 출력 제거로 코드 간소화
- 테스트 코드를 새로운 로직에 맞게 수정
- 8개 테스트 케이스 모두 통과


- 119 카드 효과로, 본인에게 사용하지 않을시 지정 타켓 유저만 hp 1 회복에서 자신을 제외한 전체 플레이어 hp 1 회복으로 수정