### PR TITLE
Feat/card_deadmatch

### DIFF
--- a/game.server/src/card/card.death_match.effect.ts
+++ b/game.server/src/card/card.death_match.effect.ts
@@ -1,12 +1,44 @@
 // cardType = 6
 import { getUserFromRoom, updateCharacterFromRoom } from "../utils/redis.util.js";
+import { CharacterStateType } from "../generated/common/enums.js";
 
-const cardDeathMatchEffect = async (roomId:number, userId:string, targetUserId:string) =>{
+const cardDeathMatchEffect = async (roomId: number, userId: string, targetUserId: string) => {
     const user = await getUserFromRoom(roomId, userId);
-    const target = await getUserFromRoom(roomId, targetUserId);
+    
     // 유효성 검증
-    if (!user || !target || !target.character) return; 
-
+    if (!user || !user.character) return;
+    
+    const target = await getUserFromRoom(roomId, targetUserId);
+    
+    // 유효성 검증
+    if (!target || !target.character) return;
+    
+    // 현피 카드 효과: 현피 상태 설정
+    // 사용자: DEATH_MATCH_TURN_STATE (현피 차례)
+    // 대상: DEATH_MATCH_STATE (현피 대기)
+    
+    user.character.stateInfo = {
+        state: CharacterStateType.DEATH_MATCH_TURN_STATE,
+        nextState: CharacterStateType.NONE_CHARACTER_STATE,
+        nextStateAt: "0",
+        stateTargetUserId: targetUserId
+    };
+    
+    target.character.stateInfo = {
+        state: CharacterStateType.DEATH_MATCH_STATE,
+        nextState: CharacterStateType.NONE_CHARACTER_STATE,
+        nextStateAt: "0",
+        stateTargetUserId: userId
+    };
+    
+    // Redis에 업데이트된 캐릭터 정보 저장
+    try {
+        await updateCharacterFromRoom(roomId, userId, user.character);
+        await updateCharacterFromRoom(roomId, targetUserId, target.character);
+        console.log(`[현피] ${user.nickname}이 ${target.nickname}에게 현피를 걸었습니다.`);
+    } catch (error) {
+        console.error(`[현피] Redis 업데이트 실패:`, error);
+    }
 }
 
 

--- a/game.server/src/card/test/card.death_match.effect.test.ts
+++ b/game.server/src/card/test/card.death_match.effect.test.ts
@@ -1,0 +1,307 @@
+import cardDeathMatchEffect from '../card.death_match.effect.js';
+import { getUserFromRoom, updateCharacterFromRoom } from '../../utils/redis.util.js';
+import { CharacterStateType } from '../../generated/common/enums.js';
+
+// Mock 설정
+jest.mock('../../utils/redis.util.js');
+const mockGetUserFromRoom = getUserFromRoom as jest.MockedFunction<typeof getUserFromRoom>;
+const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.MockedFunction<typeof updateCharacterFromRoom>;
+
+describe('cardDeathMatchEffect', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('성공 케이스', () => {
+        it('현피 카드 사용 시 두 플레이어의 상태를 올바르게 설정해야 함', async () => {
+            // Given
+            const roomId = 1;
+            const userId = 'user1';
+            const targetUserId = 'user2';
+            
+            const user = {
+                id: userId,
+                nickname: '사용자1',
+                character: {
+                    stateInfo: {
+                        state: CharacterStateType.NONE_CHARACTER_STATE,
+                        nextState: CharacterStateType.NONE_CHARACTER_STATE,
+                        nextStateAt: '0',
+                        stateTargetUserId: '0'
+                    }
+                }
+            };
+            
+            const target = {
+                id: targetUserId,
+                nickname: '사용자2',
+                character: {
+                    stateInfo: {
+                        state: CharacterStateType.NONE_CHARACTER_STATE,
+                        nextState: CharacterStateType.NONE_CHARACTER_STATE,
+                        nextStateAt: '0',
+                        stateTargetUserId: '0'
+                    }
+                }
+            };
+
+            mockGetUserFromRoom
+                .mockResolvedValueOnce(user)
+                .mockResolvedValueOnce(target);
+            mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
+
+            // When
+            await cardDeathMatchEffect(roomId, userId, targetUserId);
+
+            // Then
+            expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
+            expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, targetUserId);
+            
+            // 사용자 상태 확인
+            expect(user.character.stateInfo.state).toBe(CharacterStateType.DEATH_MATCH_TURN_STATE);
+            expect(user.character.stateInfo.stateTargetUserId).toBe(targetUserId);
+            
+            // 대상 상태 확인
+            expect(target.character.stateInfo.state).toBe(CharacterStateType.DEATH_MATCH_STATE);
+            expect(target.character.stateInfo.stateTargetUserId).toBe(userId);
+            
+            // Redis 업데이트 확인
+            expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, user.character);
+            expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, targetUserId, target.character);
+        });
+
+        it('현피 카드 사용 시 콘솔 로그가 출력되어야 함', async () => {
+            // Given
+            const roomId = 1;
+            const userId = 'user1';
+            const targetUserId = 'user2';
+            
+            const user = {
+                id: userId,
+                nickname: '사용자1',
+                character: { stateInfo: {} }
+            };
+            
+            const target = {
+                id: targetUserId,
+                nickname: '사용자2',
+                character: { stateInfo: {} }
+            };
+
+            mockGetUserFromRoom
+                .mockResolvedValueOnce(user)
+                .mockResolvedValueOnce(target);
+            mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
+
+            const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+            // When
+            await cardDeathMatchEffect(roomId, userId, targetUserId);
+
+            // Then
+            expect(consoleSpy).toHaveBeenCalledWith('[현피] 사용자1이 사용자2에게 현피를 걸었습니다.');
+            
+            consoleSpy.mockRestore();
+        });
+    });
+
+    describe('실패 케이스', () => {
+        it('사용자가 존재하지 않으면 함수가 조기 종료되어야 함', async () => {
+            // Given
+            const roomId = 1;
+            const userId = 'user1';
+            const targetUserId = 'user2';
+            
+            mockGetUserFromRoom.mockResolvedValue(null);
+
+            // When
+            await cardDeathMatchEffect(roomId, userId, targetUserId);
+
+            // Then
+            expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
+            expect(mockGetUserFromRoom).not.toHaveBeenCalledWith(roomId, targetUserId);
+            expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+        });
+
+        it('대상이 존재하지 않으면 함수가 조기 종료되어야 함', async () => {
+            // Given
+            const roomId = 1;
+            const userId = 'user1';
+            const targetUserId = 'user2';
+            
+            const user = {
+                id: userId,
+                nickname: '사용자1',
+                character: { stateInfo: {} }
+            };
+
+            mockGetUserFromRoom
+                .mockResolvedValueOnce(user)
+                .mockResolvedValueOnce(null);
+
+            // When
+            await cardDeathMatchEffect(roomId, userId, targetUserId);
+
+            // Then
+            expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
+            expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, targetUserId);
+            expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+        });
+
+        it('사용자의 캐릭터가 없으면 함수가 조기 종료되어야 함', async () => {
+            // Given
+            const roomId = 1;
+            const userId = 'user1';
+            const targetUserId = 'user2';
+            
+            const user = {
+                id: userId,
+                nickname: '사용자1',
+                character: null
+            };
+
+            mockGetUserFromRoom.mockResolvedValue(user);
+
+            // When
+            await cardDeathMatchEffect(roomId, userId, targetUserId);
+
+            // Then
+            expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
+            expect(mockGetUserFromRoom).not.toHaveBeenCalledWith(roomId, targetUserId);
+            expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+        });
+
+        it('대상의 캐릭터가 없으면 함수가 조기 종료되어야 함', async () => {
+            // Given
+            const roomId = 1;
+            const userId = 'user1';
+            const targetUserId = 'user2';
+            
+            const user = {
+                id: userId,
+                nickname: '사용자1',
+                character: { stateInfo: {} }
+            };
+            
+            const target = {
+                id: targetUserId,
+                nickname: '사용자2',
+                character: null
+            };
+
+            mockGetUserFromRoom
+                .mockResolvedValueOnce(user)
+                .mockResolvedValueOnce(target);
+
+            // When
+            await cardDeathMatchEffect(roomId, userId, targetUserId);
+
+            // Then
+            expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
+            expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, targetUserId);
+            expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+        });
+
+        it('Redis 업데이트 실패 시 에러가 로그에 출력되어야 함', async () => {
+            // Given
+            const roomId = 1;
+            const userId = 'user1';
+            const targetUserId = 'user2';
+            
+            const user = {
+                id: userId,
+                nickname: '사용자1',
+                character: { stateInfo: {} }
+            };
+            
+            const target = {
+                id: targetUserId,
+                nickname: '사용자2',
+                character: { stateInfo: {} }
+            };
+
+            mockGetUserFromRoom
+                .mockResolvedValueOnce(user)
+                .mockResolvedValueOnce(target);
+            mockUpdateCharacterFromRoom.mockRejectedValue(new Error('Redis 업데이트 실패'));
+
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+            // When
+            await cardDeathMatchEffect(roomId, userId, targetUserId);
+
+            // Then
+            expect(consoleErrorSpy).toHaveBeenCalledWith('[현피] Redis 업데이트 실패:', expect.any(Error));
+            
+            consoleErrorSpy.mockRestore();
+        });
+    });
+
+    describe('상태 설정 검증', () => {
+        it('사용자의 상태가 DEATH_MATCH_TURN_STATE로 설정되어야 함', async () => {
+            // Given
+            const roomId = 1;
+            const userId = 'user1';
+            const targetUserId = 'user2';
+            
+            const user = {
+                id: userId,
+                nickname: '사용자1',
+                character: { stateInfo: {} }
+            };
+            
+            const target = {
+                id: targetUserId,
+                nickname: '사용자2',
+                character: { stateInfo: {} }
+            };
+
+            mockGetUserFromRoom
+                .mockResolvedValueOnce(user)
+                .mockResolvedValueOnce(target);
+            mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
+
+            // When
+            await cardDeathMatchEffect(roomId, userId, targetUserId);
+
+            // Then
+            expect(user.character.stateInfo.state).toBe(CharacterStateType.DEATH_MATCH_TURN_STATE);
+            expect(user.character.stateInfo.nextState).toBe(CharacterStateType.NONE_CHARACTER_STATE);
+            expect(user.character.stateInfo.nextStateAt).toBe('0');
+            expect(user.character.stateInfo.stateTargetUserId).toBe(targetUserId);
+        });
+
+        it('대상의 상태가 DEATH_MATCH_STATE로 설정되어야 함', async () => {
+            // Given
+            const roomId = 1;
+            const userId = 'user1';
+            const targetUserId = 'user2';
+            
+            const user = {
+                id: userId,
+                nickname: '사용자1',
+                character: { stateInfo: {} }
+            };
+            
+            const target = {
+                id: targetUserId,
+                nickname: '사용자2',
+                character: { stateInfo: {} }
+            };
+
+            mockGetUserFromRoom
+                .mockResolvedValueOnce(user)
+                .mockResolvedValueOnce(target);
+            mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
+
+            // When
+            await cardDeathMatchEffect(roomId, userId, targetUserId);
+
+            // Then
+            expect(target.character.stateInfo.state).toBe(CharacterStateType.DEATH_MATCH_STATE);
+            expect(target.character.stateInfo.nextState).toBe(CharacterStateType.NONE_CHARACTER_STATE);
+            expect(target.character.stateInfo.nextStateAt).toBe('0');
+            expect(target.character.stateInfo.stateTargetUserId).toBe(userId);
+        });
+    });
+});

--- a/game.server/src/handlers/request/reaction.request.handler.ts
+++ b/game.server/src/handlers/request/reaction.request.handler.ts
@@ -1,9 +1,59 @@
-import { GameSocket } from "../../type/game.socket.js";
-import { C2SReactionRequest } from "../../generated/packet/game_actions.js";
-import { GamePacket } from "../../generated/gamePacket.js";
+import { GameSocket } from '../../type/game.socket.js';
+import { C2SReactionRequest } from '../../generated/packet/game_actions.js';
+import { GamePacket } from '../../generated/gamePacket.js';
+import { CharacterStateType } from '../../generated/common/enums.js';
+import { getRoom, updateCharacterFromRoom } from '../../utils/redis.util.js';
 
+const reactionRequestHandler = async (socket: GameSocket, gamePacket: GamePacket) => {
+	if (!socket.roomId) return;
 
-const reactionRequestHandler = (socket:GameSocket, gamePacket:GamePacket) => {
+	const room = await getRoom(socket.roomId);
+	if (!room) return;
 
-}
-export default  reactionRequestHandler;
+	const user = room.users.find((u) => u.id === socket.userId);
+	if (!user || !user.character) return;
+
+	switch (user.character.stateInfo?.state) {
+		case CharacterStateType.DEATH_MATCH_TURN_STATE:
+			// 현피 차례에서 빵야! 카드가 없을 때만 호출됨
+			await handleDeathMatchFailure(room, user);
+			break;
+
+		case CharacterStateType.DEATH_MATCH_STATE:
+			// 현피 대기 상태에서는 아무것도 하지 않음
+			break;
+	}
+};
+
+// 현피 실패 처리 (빵야! 카드 없음)
+const handleDeathMatchFailure = async (room: any, user: any) => {
+	// 패배 처리
+	user.character.hp -= 1;
+
+	// 현피 종료 (양쪽 상태 초기화)
+	const targetUserId = user.character.stateInfo.stateTargetUserId;
+	const target = room.users.find((u: any) => u.id === targetUserId);
+
+	if (target && target.character) {
+		// 사용자 상태 초기화
+		user.character.stateInfo.state = CharacterStateType.NONE_CHARACTER_STATE;
+		user.character.stateInfo.stateTargetUserId = '0';
+
+		// 대상 상태 초기화
+		target.character.stateInfo.state = CharacterStateType.NONE_CHARACTER_STATE;
+		target.character.stateInfo.stateTargetUserId = '0';
+
+		// Redis 업데이트
+		try {
+			await updateCharacterFromRoom(room.id, user.id, user.character);
+			await updateCharacterFromRoom(room.id, target.id, target.character);
+			console.log(
+				`[현피] ${user.nickname} 패배! 체력: ${user.character.hp + 1} → ${user.character.hp}`,
+			);
+		} catch (error) {
+			console.error(`[현피] Redis 업데이트 실패:`, error);
+		}
+	}
+};
+
+export default reactionRequestHandler;


### PR DESCRIPTION
## 제목
현피 카드 이펙트 로직 및 클라이언트의 현피관련 리엑션 요청 처리 구현

## 내용
클라이언트 코드를 확인해보니 
현피 차례인 플레이어가 bbang 카드를 가지고 있으면 클라이언트에서 UseCardRequest를 서버로 보내고
현피 차례인 플레이어가 bbang 카드를 가지고 있지 않은 즉, 데스매치 패배 상황에서만 서버로 ReactionRequest를 서버로 보내고 있었습니다.
따라서 클라이언트가 ReactionRequest를 보낼 때만 서버측에서 현피 실패 처리 로직을 수행 하도록 reactionRequestHandler를 수정했습니다.