### PR TITLE
Feat/container

### DIFF
--- a/game.server/src/card/card.auto_shield.effect.ts
+++ b/game.server/src/card/card.auto_shield.effect.ts
@@ -13,14 +13,14 @@ const cardAutoShieldEffect = async (roomId: number, userId: string) => {
 	// }
 
 	// 손에서 자동 쉴드 카드 찾아서 제거
-	const cardIndex = user.character.handCards.findIndex(
-		(card) => card.type === CardType.AUTO_SHIELD,
-	);
-	if (cardIndex === -1) {
-		// 카드 없으면 로직 중단
-		return;
-	}
-	user.character.handCards.splice(cardIndex, 1);
+	// const cardIndex = user.character.handCards.findIndex(
+	// 	(card) => card.type === CardType.AUTO_SHIELD,
+	// );
+	// if (cardIndex === -1) {
+	// 	// 카드 없으면 로직 중단
+	// 	return;
+	// }
+	// user.character.handCards.splice(cardIndex, 1);
 
 	// 자동 쉴드 장착
 	user.character.equips.push(CardType.AUTO_SHIELD);

--- a/game.server/src/card/test/card.auto_shield.effect.test.ts
+++ b/game.server/src/card/test/card.auto_shield.effect.test.ts
@@ -73,7 +73,7 @@ describe('cardAutoShieldEffect (장착 테스트)', () => {
 		await cardAutoShieldEffect(roomId, userId);
 
 		expect(user.character!.equips).toContain(CardType.AUTO_SHIELD);
-		expect(user.character!.handCards.length).toBe(0);
+		//expect(user.character!.handCards.length).toBe(0);
 		expect(updateCharacterFromRoom).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
# 자동 실드 2중으로 소지 카드 제거하는 로직 삭제
## 내용
- 자동 실드 2중으로 소지 카드 제거하는 로직 삭제'
- 자동 실드 로직 테스트에서 해당로직에서 카드가 제거되는지 확인하는 expect문 삭제
- 수정된 테스트 케이스 실행 -> 통과