### PR TITLE
Fix/test call 119 effect

### DIFF
--- a/game.server/src/card/test/card.call_119.effect.test.ts
+++ b/game.server/src/card/test/card.call_119.effect.test.ts
@@ -64,7 +64,7 @@ describe('cardCall119Effect', () => {
 			mockGetUserFromRoom.mockResolvedValue(user);
 			mockGetRoom.mockResolvedValue(null);
 
-			await cardCall119Effect(roomId, userId, ''); // 나머지 플레이어 회복 시도
+			await cardCall119Effect(roomId, userId, '0'); // 나머지 플레이어 회복 시도
 
 			expect(mockGetRoom).toHaveBeenCalledWith(roomId);
 			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
@@ -84,7 +84,7 @@ describe('cardCall119Effect', () => {
 			handCardsCount: 0,
 		});
 
-		it('자신의 체력을 1 회복한다 (targetUserId가 있는 경우)', async () => {
+		it('자신의 체력을 1 회복한다 (targetUserId가 "0"이 아닌 경우)', async () => {
 			const user = {
 				id: userId,
 				nickname: 'user1',
@@ -95,7 +95,7 @@ describe('cardCall119Effect', () => {
 
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
-			await cardCall119Effect(roomId, userId, 'self'); // targetUserId가 있으면 자신 회복
+			await cardCall119Effect(roomId, userId, 'user2'); // targetUserId != "0"이므로 자신 회복
 
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
 				...user.character,
@@ -108,7 +108,7 @@ describe('cardCall119Effect', () => {
 			consoleSpy.mockRestore();
 		});
 
-		it('나머지 플레이어들의 체력을 1 회복한다 (targetUserId가 없는 경우)', async () => {
+		it('나머지 플레이어들의 체력을 1 회복한다 (targetUserId가 "0"인 경우)', async () => {
 			const user = {
 				id: userId,
 				nickname: 'user1',
@@ -140,7 +140,7 @@ describe('cardCall119Effect', () => {
 
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
-			await cardCall119Effect(roomId, userId, ''); // targetUserId가 없으면 나머지 회복
+			await cardCall119Effect(roomId, userId, '0'); // targetUserId가 "0"이면 나머지 회복
 
 			// user2와 user3의 체력이 회복되어야 함 (user1은 제외)
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(2);
@@ -167,7 +167,7 @@ describe('cardCall119Effect', () => {
 
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
-			await cardCall119Effect(roomId, userId, 'self'); // 자신 회복
+			await cardCall119Effect(roomId, userId, 'user2'); // 자신 회복
 
 			expect(consoleSpy).toHaveBeenCalledWith('[119 호출] user1의 체력이 이미 최대치(4)입니다.');
 			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
@@ -186,7 +186,7 @@ describe('cardCall119Effect', () => {
 
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
-			await cardCall119Effect(roomId, userId, 'self'); // 자신 회복
+			await cardCall119Effect(roomId, userId, 'user2'); // 자신 회복
 
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
 				...user.character,
@@ -210,7 +210,7 @@ describe('cardCall119Effect', () => {
 
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
-			await cardCall119Effect(roomId, userId, 'self'); // 자신 회복
+			await cardCall119Effect(roomId, userId, 'user2'); // 자신 회복
 
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
 				...user.character,
@@ -249,7 +249,7 @@ describe('cardCall119Effect', () => {
 			const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 
 			// 에러가 발생해도 함수가 정상적으로 처리되는지 확인
-			await expect(cardCall119Effect(roomId, userId, 'self')).resolves.not.toThrow();
+			await expect(cardCall119Effect(roomId, userId, 'user2')).resolves.not.toThrow();
 
 			// 에러 로그가 출력되는지 확인
 			expect(consoleErrorSpy).toHaveBeenCalledWith(

--- a/game.server/src/card/test/card.hand_gun.effect.test.ts
+++ b/game.server/src/card/test/card.hand_gun.effect.test.ts
@@ -53,69 +53,41 @@ describe('cardHandGunEffect', () => {
 		});
 	});
 
-	describe('빵야! 횟수 증가 로직', () => {
-		const createMockCharacter = (bbangCount: number) => ({
+	describe('무기 설정 로직', () => {
+		const createMockCharacter = (weapon: number) => ({
 			characterType: CharacterType.RED,
 			roleType: RoleType.TARGET,
 			hp: 3,
-			weapon: 0,
+			weapon,
 			equips: [],
 			debuffs: [],
 			handCards: [],
-			bbangCount,
+			bbangCount: 0,
 			handCardsCount: 0,
 		});
 
-		it('자신의 빵야! 횟수를 2로 설정한다 (targetUserId 무시)', async () => {
+		it('자신의 무기를 핸드건(14)으로 설정한다', async () => {
 			const user = {
 				id: userId,
 				nickname: 'user1',
-				character: createMockCharacter(1), // 기본 빵야! 횟수
+				character: createMockCharacter(0), // 기본 무기 없음
 			};
 
 			mockGetUserFromRoom.mockResolvedValue(user);
 
-			await cardHandGunEffect(roomId, userId); // targetUserId는 무시됨
+			await cardHandGunEffect(roomId, userId);
 
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
 				...user.character,
-				bbangCount: 2, // 2로 고정 설정
+				weapon: 14, // 핸드건 무기로 설정
 			});
 		});
 
-		it('이미 핸드건 효과를 받은 경우 설정하지 않는다 (bbangCount >= 2)', async () => {
+		it('이미 핸드건을 장착한 경우에도 다시 설정한다', async () => {
 			const user = {
 				id: userId,
 				nickname: 'user1',
-				character: createMockCharacter(2), // 이미 핸드건 효과 적용됨
-			};
-
-			mockGetUserFromRoom.mockResolvedValue(user);
-
-			await cardHandGunEffect(roomId, userId);
-
-			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
-		});
-
-		it('빵야! 횟수가 3 이상인 경우 설정하지 않는다', async () => {
-			const user = {
-				id: userId,
-				nickname: 'user1',
-				character: createMockCharacter(3), // 빵야! 횟수 3
-			};
-
-			mockGetUserFromRoom.mockResolvedValue(user);
-
-			await cardHandGunEffect(roomId, userId);
-
-			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
-		});
-
-		it('빵야! 횟수가 0인 경우 2로 설정한다', async () => {
-			const user = {
-				id: userId,
-				nickname: 'user1',
-				character: createMockCharacter(0), // 빵야! 횟수 0
+				character: createMockCharacter(14), // 이미 핸드건 장착
 			};
 
 			mockGetUserFromRoom.mockResolvedValue(user);
@@ -124,7 +96,24 @@ describe('cardHandGunEffect', () => {
 
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
 				...user.character,
-				bbangCount: 2, // 2로 고정 설정
+				weapon: 14, // 핸드건 무기로 설정
+			});
+		});
+
+		it('다른 무기를 장착한 경우 핸드건으로 교체한다', async () => {
+			const user = {
+				id: userId,
+				nickname: 'user1',
+				character: createMockCharacter(15), // 다른 무기 장착
+			};
+
+			mockGetUserFromRoom.mockResolvedValue(user);
+
+			await cardHandGunEffect(roomId, userId);
+
+			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
+				...user.character,
+				weapon: 14, // 핸드건 무기로 교체
 			});
 		});
 	});

--- a/game.server/src/handlers/pass.debuff.handler.ts
+++ b/game.server/src/handlers/pass.debuff.handler.ts
@@ -11,13 +11,36 @@ const passDebuffHandler = async (socket: GameSocket, gamePacket: GamePacket) => 
 	const payload = getGamePacketType(gamePacket, gamePackTypeSelect.passDebuffRequest);
 	if (!payload) return;
 
+	// 잘못된 요청인 경우 UseCase를 호출하지 않음
+	if (!socket.userId || !socket.roomId) {
+		console.warn('[PassDebuff] 잘못된 소켓 정보:', { userId: socket.userId, roomId: socket.roomId });
+		return;
+	}
+
 	const req = payload.passDebuffRequest as C2SPassDebuffRequest;
 
-	// UseCase 호출
-	const response = await passDebuffUseCase(socket, req);
+	try {
+		// UseCase 호출
+		const response = await passDebuffUseCase(socket, req);
 
-	// 요청자에게 응답 전송
-	sendData(socket, response, GamePacketType.passDebuffResponse);
+		// 요청자에게 응답 전송
+		sendData(socket, response, GamePacketType.passDebuffResponse);
+	} catch (error) {
+		console.error('[PassDebuff] UseCase 실행 중 오류 발생:', error);
+		
+		// 에러 발생 시 실패 응답 전송
+		const errorResponse = {
+			payload: {
+				oneofKind: GamePacketType.passDebuffResponse,
+				passDebuffResponse: {
+					success: false,
+					failCode: GlobalFailCode.UNKNOWN_ERROR,
+				},
+			},
+		};
+		
+		sendData(socket, errorResponse, GamePacketType.passDebuffResponse);
+	}
 };
 
 export default passDebuffHandler;

--- a/game.server/src/useCase/pass.debuff/pass.debuff.usecase.ts
+++ b/game.server/src/useCase/pass.debuff/pass.debuff.usecase.ts
@@ -17,9 +17,10 @@ const passDebuffUseCase = async (
 
 	try {
 		// 1. 방 존재 확인
-		let room;
-		room = getRoom(parseInt(roomId));
-		return setPassDebuffResponse(false, GlobalFailCode.ROOM_NOT_FOUND);
+		const room = getRoom(parseInt(roomId));
+		if (!room) {
+			return setPassDebuffResponse(false, GlobalFailCode.ROOM_NOT_FOUND);
+		}
 
 		// 2. 요청자와 대상자가 같은 방에 있는지 확인
 		const fromUser = room.users.find((u) => u.id === userId);


### PR DESCRIPTION
🐛fix: card.call_119.effect.test 테스트 케이스 수정

- targetUserId가 "0"인 경우와 "0"이 아닌 경우에 대한 테스트 케이스 수정
- 회복 로직에 맞춰 테스트 시나리오 변경