### PR TITLE
♻️ refactor: card.call_119.effect 리팩토링 및 에러 처리 개선

### DIFF
--- a/game.server/src/card/test/card.call_119.effect.test.ts
+++ b/game.server/src/card/test/card.call_119.effect.test.ts
@@ -1,19 +1,17 @@
 import cardCall119Effect from '../card.call_119.effect';
-import { getUserFromRoom, updateCharacterFromRoom, getRoom } from '../../utils/redis.util';
+import { getRoom, updateCharacterFromRoom } from '../../utils/room.utils';
 import { CharacterType, RoleType } from '../../generated/common/enums';
 
 // Mock 설정
-jest.mock('../../utils/redis.util', () => ({
-	getUserFromRoom: jest.fn(),
-	updateCharacterFromRoom: jest.fn(),
+jest.mock('../../utils/room.utils', () => ({
 	getRoom: jest.fn(),
+	updateCharacterFromRoom: jest.fn(),
 }));
 
-const mockGetUserFromRoom = getUserFromRoom as jest.MockedFunction<typeof getUserFromRoom>;
+const mockGetRoom = getRoom as jest.MockedFunction<typeof getRoom>;
 const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.MockedFunction<
 	typeof updateCharacterFromRoom
 >;
-const mockGetRoom = getRoom as jest.MockedFunction<typeof getRoom>;
 
 describe('cardCall119Effect', () => {
 	const roomId = 1;
@@ -25,49 +23,44 @@ describe('cardCall119Effect', () => {
 	});
 
 	describe('유효성 검증', () => {
-		it('사용자가 없으면 함수가 종료된다', async () => {
-			mockGetUserFromRoom.mockResolvedValue(null);
+		it('방이 없으면 함수가 종료된다', async () => {
+			mockGetRoom.mockImplementation(() => {
+				throw new Error('Room not found');
+			});
 
-			await cardCall119Effect(roomId, userId, targetUserId);
-
-			expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
-			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
-		});
-
-		it('사용자의 캐릭터가 없으면 함수가 종료된다', async () => {
-			const user = { id: userId, nickname: 'testUser' };
-			mockGetUserFromRoom.mockResolvedValue(user);
-
-			await cardCall119Effect(roomId, userId, targetUserId);
-
-			expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
-			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
-		});
-
-		it('방 정보를 가져올 수 없으면 함수가 종료된다', async () => {
-			const user = {
-				id: userId,
-				nickname: 'user1',
-				character: {
-					characterType: CharacterType.RED,
-					roleType: RoleType.TARGET,
-					hp: 3,
-					weapon: 0,
-					equips: [],
-					debuffs: [],
-					handCards: [],
-					bbangCount: 0,
-					handCardsCount: 0,
-				},
-			};
-
-			mockGetUserFromRoom.mockResolvedValue(user);
-			mockGetRoom.mockResolvedValue(null);
-
-			await cardCall119Effect(roomId, userId, ''); // 나머지 플레이어 회복 시도
+			const result = await cardCall119Effect(roomId, userId, targetUserId);
 
 			expect(mockGetRoom).toHaveBeenCalledWith(roomId);
 			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+			expect(result).toBe(false);
+		});
+
+		it('사용자가 없으면 함수가 종료된다', async () => {
+			const mockRoom = {
+				id: roomId,
+				users: [{ id: 'otherUser', nickname: 'other' }], // 다른 유저만 있음
+			};
+			mockGetRoom.mockReturnValue(mockRoom);
+
+			const result = await cardCall119Effect(roomId, userId, targetUserId);
+
+			expect(mockGetRoom).toHaveBeenCalledWith(roomId);
+			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+			expect(result).toBe(false);
+		});
+
+		it('사용자의 캐릭터가 없으면 함수가 종료된다', async () => {
+			const mockRoom = {
+				id: roomId,
+				users: [{ id: userId, nickname: 'testUser' }], // 캐릭터 없음
+			};
+			mockGetRoom.mockReturnValue(mockRoom);
+
+			const result = await cardCall119Effect(roomId, userId, targetUserId);
+
+			expect(mockGetRoom).toHaveBeenCalledWith(roomId);
+			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+			expect(result).toBe(false);
 		});
 	});
 
@@ -85,20 +78,26 @@ describe('cardCall119Effect', () => {
 		});
 
 		it('자신의 체력을 1 회복한다 (targetUserId가 있는 경우)', async () => {
-			const user = {
-				id: userId,
-				nickname: 'user1',
-				character: createMockCharacter(CharacterType.RED, 2),
+			const mockCharacter = createMockCharacter(CharacterType.RED, 2);
+			const mockRoom = {
+				id: roomId,
+				users: [{
+					id: userId,
+					nickname: 'user1',
+					character: mockCharacter,
+				}],
 			};
 
-			mockGetUserFromRoom.mockResolvedValue(user);
+			mockGetRoom.mockReturnValue(mockRoom);
 
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
-			await cardCall119Effect(roomId, userId, 'self'); // targetUserId가 있으면 자신 회복
+			const result = await cardCall119Effect(roomId, userId, 'self'); // targetUserId가 있으면 자신 회복
 
+			expect(result).toBe(true);
+			expect(mockGetRoom).toHaveBeenCalledWith(roomId);
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
-				...user.character,
+				...mockCharacter,
 				hp: 3,
 			});
 			expect(consoleSpy).toHaveBeenCalledWith(
@@ -109,47 +108,48 @@ describe('cardCall119Effect', () => {
 		});
 
 		it('나머지 플레이어들의 체력을 1 회복한다 (targetUserId가 없는 경우)', async () => {
-			const user = {
-				id: userId,
-				nickname: 'user1',
-				character: createMockCharacter(CharacterType.RED, 4),
-			};
-			const room = {
+			const userCharacter = createMockCharacter(CharacterType.RED, 4);
+			const user2Character = createMockCharacter(CharacterType.SHARK, 2);
+			const user3Character = createMockCharacter(CharacterType.DINOSAUR, 1);
+			
+			const mockRoom = {
 				id: roomId,
-				ownerId: userId,
-				name: 'Test Room',
-				maxUserNum: 4,
-				state: 1, // WAIT
 				users: [
-					user,
+					{
+						id: userId,
+						nickname: 'user1',
+						character: userCharacter,
+					},
 					{
 						id: 'user2',
 						nickname: 'user2',
-						character: createMockCharacter(CharacterType.SHARK, 2),
+						character: user2Character,
 					},
 					{
 						id: 'user3',
 						nickname: 'user3',
-						character: createMockCharacter(CharacterType.DINOSAUR, 1),
+						character: user3Character,
 					},
 				],
 			};
 
-			mockGetUserFromRoom.mockResolvedValue(user);
-			mockGetRoom.mockResolvedValue(room);
+			mockGetRoom.mockReturnValue(mockRoom);
 
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
-			await cardCall119Effect(roomId, userId, ''); // targetUserId가 없으면 나머지 회복
+			const result = await cardCall119Effect(roomId, userId, '0'); // targetUserId가 "0"이면 나머지 회복
 
+			expect(result).toBe(true);
+			expect(mockGetRoom).toHaveBeenCalledWith(roomId);
+			
 			// user2와 user3의 체력이 회복되어야 함 (user1은 제외)
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(2);
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, 'user2', {
-				...room.users[1].character,
+				...user2Character,
 				hp: 3,
 			});
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, 'user3', {
-				...room.users[2].character,
+				...user3Character,
 				hp: 2,
 			});
 
@@ -157,18 +157,23 @@ describe('cardCall119Effect', () => {
 		});
 
 		it('최대 체력에 도달한 경우 회복하지 않는다', async () => {
-			const user = {
-				id: userId,
-				nickname: 'user1',
-				character: createMockCharacter(CharacterType.RED, 4), // 최대 체력
+			const mockCharacter = createMockCharacter(CharacterType.RED, 4); // 최대 체력
+			const mockRoom = {
+				id: roomId,
+				users: [{
+					id: userId,
+					nickname: 'user1',
+					character: mockCharacter,
+				}],
 			};
 
-			mockGetUserFromRoom.mockResolvedValue(user);
+			mockGetRoom.mockReturnValue(mockRoom);
 
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
-			await cardCall119Effect(roomId, userId, 'self'); // 자신 회복
+			const result = await cardCall119Effect(roomId, userId, 'self'); // 자신 회복
 
+			expect(result).toBe(true);
 			expect(consoleSpy).toHaveBeenCalledWith('[119 호출] user1의 체력이 이미 최대치(4)입니다.');
 			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
 
@@ -176,20 +181,25 @@ describe('cardCall119Effect', () => {
 		});
 
 		it('공룡이 캐릭터의 최대 체력(3)을 초과하지 않는다', async () => {
-			const user = {
-				id: userId,
-				nickname: 'user1',
-				character: createMockCharacter(CharacterType.DINOSAUR, 2),
+			const mockCharacter = createMockCharacter(CharacterType.DINOSAUR, 2);
+			const mockRoom = {
+				id: roomId,
+				users: [{
+					id: userId,
+					nickname: 'user1',
+					character: mockCharacter,
+				}],
 			};
 
-			mockGetUserFromRoom.mockResolvedValue(user);
+			mockGetRoom.mockReturnValue(mockRoom);
 
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
-			await cardCall119Effect(roomId, userId, 'self'); // 자신 회복
+			const result = await cardCall119Effect(roomId, userId, 'self'); // 자신 회복
 
+			expect(result).toBe(true);
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
-				...user.character,
+				...mockCharacter,
 				hp: 3, // 최대 체력 3에 제한됨
 			});
 			expect(consoleSpy).toHaveBeenCalledWith(
@@ -200,20 +210,25 @@ describe('cardCall119Effect', () => {
 		});
 
 		it('핑크슬라임 캐릭터의 최대 체력(3)을 초과하지 않는다', async () => {
-			const user = {
-				id: userId,
-				nickname: 'user1',
-				character: createMockCharacter(CharacterType.PINK_SLIME, 2),
+			const mockCharacter = createMockCharacter(CharacterType.PINK_SLIME, 2);
+			const mockRoom = {
+				id: roomId,
+				users: [{
+					id: userId,
+					nickname: 'user1',
+					character: mockCharacter,
+				}],
 			};
 
-			mockGetUserFromRoom.mockResolvedValue(user);
+			mockGetRoom.mockReturnValue(mockRoom);
 
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
-			await cardCall119Effect(roomId, userId, 'self'); // 자신 회복
+			const result = await cardCall119Effect(roomId, userId, 'self'); // 자신 회복
 
+			expect(result).toBe(true);
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
-				...user.character,
+				...mockCharacter,
 				hp: 3, // 최대 체력 3에 제한됨
 			});
 			expect(consoleSpy).toHaveBeenCalledWith(
@@ -225,35 +240,61 @@ describe('cardCall119Effect', () => {
 	});
 
 	describe('에러 처리', () => {
+		it('방을 찾을 수 없으면 에러가 처리된다', async () => {
+			mockGetRoom.mockImplementation(() => {
+				throw new Error('Room not found');
+			});
+
+			const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+			const result = await cardCall119Effect(roomId, userId, 'self');
+
+			expect(result).toBe(false);
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				'[119 호출] 방 또는 유저를 찾을 수 없음:',
+				expect.any(Error),
+			);
+
+			consoleErrorSpy.mockRestore();
+		});
+
 		it('updateCharacterFromRoom에서 에러가 발생해도 함수가 정상적으로 처리된다', async () => {
-			const user = {
-				id: userId,
-				nickname: 'user1',
-				character: {
-					characterType: CharacterType.RED,
-					roleType: RoleType.TARGET,
-					hp: 2,
-					weapon: 0,
-					equips: [],
-					debuffs: [],
-					handCards: [],
-					bbangCount: 0,
-					handCardsCount: 0,
-				},
+			const mockCharacter = {
+				characterType: CharacterType.RED,
+				roleType: RoleType.TARGET,
+				hp: 2,
+				weapon: 0,
+				equips: [],
+				debuffs: [],
+				handCards: [],
+				bbangCount: 0,
+				handCardsCount: 0,
 			};
 
-			mockGetUserFromRoom.mockResolvedValue(user);
-			mockUpdateCharacterFromRoom.mockRejectedValue(new Error('Redis error'));
+			const mockRoom = {
+				id: roomId,
+				users: [{
+					id: userId,
+					nickname: 'user1',
+					character: mockCharacter,
+				}],
+			};
+
+			mockGetRoom.mockReturnValue(mockRoom);
+			mockUpdateCharacterFromRoom.mockImplementation(() => {
+				throw new Error('Update error');
+			});
 
 			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 			const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 
 			// 에러가 발생해도 함수가 정상적으로 처리되는지 확인
-			await expect(cardCall119Effect(roomId, userId, 'self')).resolves.not.toThrow();
+			const result = await cardCall119Effect(roomId, userId, 'self');
 
+			expect(result).toBe(true);
 			// 에러 로그가 출력되는지 확인
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
-				'[119 호출] Redis 업데이트 실패:',
+				'[119 호출] 방 업데이트 실패:',
 				expect.any(Error),
 			);
 


### PR DESCRIPTION
## 내용
- Redis 대신 room.utils의 getRoom 사용으로 유저 및 방 정보 접근 방식 변경
- 테스트 코드 업데이트 및 새로운 구조에 맞게 수정