### PR TITLE
스텔스 수트 테스트코드 작성 완료

### DIFF
--- a/game.server/src/card/card.stealth_suit.effect.ts
+++ b/game.server/src/card/card.stealth_suit.effect.ts
@@ -1,36 +1,35 @@
 // cardType = 20
+import { CardType } from '../generated/common/enums';
 import { getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
-import { CardType } from '../generated/common/enums.js';
 
 const cardStealthSuitEffect = (roomId: number, userId: string): boolean => {
-	const user = getUserFromRoom(roomId, userId);
-
-	// 유효성 검증
-	if (!user || !user.character) return false;
-
-	// 스텔스 장치 카드 효과: 장비 착용
-	// 장비 카드이므로 자신에게만 적용 (targetUserId 무시)
-
-	// 기존 스텔스 장치가 있는지 확인 (중복 착용 방지)
-	const existingStealthIndex = user.character.equips.findIndex(
-		(equipId) => equipId === CardType.STEALTH_SUIT,
-	);
-
-	if (existingStealthIndex >= 0) {
-		// 이미 스텔스 장치를 착용 중인 경우 - 교체 (기존 장비 제거 후 새로 추가)
-		user.character.equips.splice(existingStealthIndex, 1);
-	}
-
-	// 스텔스 장치 장착 (장비 ID: CardType.STEALTH_SUIT)
-	user.character.equips.push(CardType.STEALTH_SUIT);
-
-	// Redis에 업데이트된 캐릭터 정보 저장
 	try {
+		const user = getUserFromRoom(roomId, userId);
+
+		// 유효성 검증
+		if (!user.character) {
+			console.warn(`[스텔스 장치] 유저의 캐릭터 정보가 없습니다: ${userId}`);
+			return false;
+		}
+
+		// 기존 스텔스 장치가 있는지 확인 (중복 착용 방지)
+		const existingStealthIndex = user.character.equips.findIndex(
+			(equipId) => equipId === CardType.STEALTH_SUIT,
+		);
+
+		if (existingStealthIndex >= 0) {
+			// 이미 스텔스 장치를 착용 중인 경우 - 교체 (기존 장비 제거 후 새로 추가)
+			user.character.equips.splice(existingStealthIndex, 1);
+		}
+
+		// 스텔스 장치 장착 (장비 ID: CardType.STEALTH_SUIT)
+		user.character.equips.push(CardType.STEALTH_SUIT);
+
 		updateCharacterFromRoom(roomId, user.id, user.character);
 		console.log(`[스텔스 장치] ${user.nickname}이 스텔스 장치를 장착했습니다.`);
 		return true;
 	} catch (error) {
-		console.error(`[스텔스 장치] Redis 업데이트 실패:`, error);
+		console.error(`[스텔스 장치] 처리 중 오류 발생:`, error);
 		return false;
 	}
 };

--- a/game.server/src/card/test/card.death_match.effect.test.ts
+++ b/game.server/src/card/test/card.death_match.effect.test.ts
@@ -138,7 +138,7 @@ describe('cardDeathMatchEffect', () => {
 			const userId = 'user1';
 			const targetUserId = 'user2';
 
-			mockGetUserFromRoom.mockReturnValue(null);
+			mockGetUserFromRoom.mockReturnValue(null as any);
 
 			// When: 현피 카드 효과 실행
  cardDeathMatchEffect(roomId, userId, targetUserId);
@@ -157,7 +157,7 @@ describe('cardDeathMatchEffect', () => {
 
 			const user: UserData = { id: userId, nickname: '사용자1', character: makeCharacter(true) };
 
-			mockGetUserFromRoom.mockReturnValueOnce(user).mockReturnValueOnce(null);
+			mockGetUserFromRoom.mockReturnValueOnce(user).mockReturnValueOnce(null as any);
 
 			// When: 현피 카드 효과 실행
  cardDeathMatchEffect(roomId, userId, targetUserId);

--- a/game.server/src/card/test/card.desert_eagle.effect.test.ts
+++ b/game.server/src/card/test/card.desert_eagle.effect.test.ts
@@ -88,9 +88,11 @@ describe('cardDesertEagleEffect', () => {
 	});
 
 	it('유저를 찾을 수 없으면 false를 반환해야 합니다', () => {
+		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+		const notFoundError = new Error('User not found');
 		// Arrange: 유저를 찾을 수 없는 상황 (에러 발생)을 설정합니다.
 		mockGetUserFromRoom.mockImplementation(() => {
-			throw new Error('User not found');
+			throw notFoundError;
 		});
 
 		// Act
@@ -99,6 +101,8 @@ describe('cardDesertEagleEffect', () => {
 		// Assert
 		expect(result).toBe(false);
 		expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled(); // 캐릭터 업데이트 함수가 호출되지 않았는지 확인
+		expect(consoleErrorSpy).toHaveBeenCalledWith('[데저트 이글] 업데이트 실패:', notFoundError);
+		consoleErrorSpy.mockRestore();
 	});
 
 	it('유저의 캐릭터 정보가 없으면 false를 반환해야 합니다', () => {
@@ -127,8 +131,6 @@ describe('cardDesertEagleEffect', () => {
 		// Assert
 		expect(result).toBe(false);
 		expect(consoleErrorSpy).toHaveBeenCalledWith('[데저트 이글] 업데이트 실패:', dbError); // 에러 로그가 정상적으로 출력되었는지 확인
-
-		// Clean up: 스파이 함수를 복원합니다.
 		consoleErrorSpy.mockRestore();
 	});
 });

--- a/game.server/src/card/test/card.satellite_target.effect.test.ts
+++ b/game.server/src/card/test/card.satellite_target.effect.test.ts
@@ -107,14 +107,18 @@ describe('위성 타겟 효과 테스트', () => {
 		});
 
 		it('타겟 유저를 찾지 못하면 false를 반환해야 함', () => {
+			const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+			const notFoundError = new Error('User not found');
 			mockGetUserFromRoom.mockImplementation(() => {
-				throw new Error('User not found');
+				throw notFoundError;
 			});
 
 			const result = cardSatelliteTargetEffect(mockRoomId, mockUserId, mockTargetUserId);
 
 			expect(result).toBe(false);
 			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+			expect(consoleErrorSpy).toHaveBeenCalledWith(`[SatelliteTarget] 위성 타겟 적용 중 오류 발생: ${notFoundError}`);
+			consoleErrorSpy.mockRestore();
 		});
 
 		it('캐릭터 정보가 없는 경우 false를 반환해야 함', () => {
@@ -128,15 +132,19 @@ describe('위성 타겟 효과 테스트', () => {
 		});
 
 		it('updateCharacterFromRoom 실패 시 false를 반환해야 함', () => {
+			const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+			const updateError = new Error('Update failed');
 			const mockTarget = createMockUser(mockTargetUserId, '타겟유저', createMockCharacter(10));
 			mockGetUserFromRoom.mockReturnValue(mockTarget as any);
 			mockUpdateCharacterFromRoom.mockImplementation(() => {
-				throw new Error('Update failed');
+				throw updateError;
 			});
 
 			const result = cardSatelliteTargetEffect(mockRoomId, mockUserId, mockTargetUserId);
 
 			expect(result).toBe(false);
+			expect(consoleErrorSpy).toHaveBeenCalledWith(`[SatelliteTarget] 위성 타겟 적용 중 오류 발생: ${updateError}`);
+			consoleErrorSpy.mockRestore();
 		});
 	});
 

--- a/game.server/src/card/test/card.stealth_suit.effect.test.ts
+++ b/game.server/src/card/test/card.stealth_suit.effect.test.ts
@@ -1,433 +1,115 @@
-/**
- * 스텔스 장치 카드 효과 테스트
- *
- * 이 테스트는 스텔스 장치 카드 효과가 올바르게 작동하는지 검증합니다.
- *
- * 테스트 시나리오:
- * 1) 기본 장착 로직
- * 2) 중복 착용 방지 및 교체 로직 (첫 번째만 교체)
- * 3) 유효성 검증
- * 4) 에러 처리
- */
-
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { CardType, CharacterStateType } from '../../generated/common/enums';
+import { CardType } from '../../generated/common/enums';
 import cardStealthSuitEffect from '../card.stealth_suit.effect';
-import { getUserFromRoom, updateCharacterFromRoom } from '../../utils/redis.util';
+import { getUserFromRoom, updateCharacterFromRoom } from '../../utils/room.utils';
+import { User } from '../../models/user.model';
+import { CharacterData } from '../../generated/common/types';
 
-// Jest 모킹
-jest.mock('../../utils/redis.util', () => ({
+jest.mock('../../utils/room.utils', () => ({
 	getUserFromRoom: jest.fn(),
 	updateCharacterFromRoom: jest.fn(),
 }));
 
-const mockGetUserFromRoom = getUserFromRoom as jest.MockedFunction<typeof getUserFromRoom>;
-const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.MockedFunction<
-	typeof updateCharacterFromRoom
->;
+const mockGetUserFromRoom = getUserFromRoom as jest.Mock;
+const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.Mock;
 
-describe('스텔스 장치 카드 효과 테스트', () => {
+describe('cardStealthSuitEffect', () => {
+	const ROOM_ID = 1;
+	const USER_ID = 'user-1';
+	let mockUser: User;
+
 	beforeEach(() => {
 		jest.clearAllMocks();
+
+		// 테스트를 위한 사용자 설정
+		mockUser = new User(USER_ID, 'TestUser');
+		mockUser.character = {
+			characterType: 0,
+			roleType: 0,
+			hp: 4,
+			weapon: 0,
+			equips: [],
+			debuffs: [],
+			handCards: [],
+			handCardsCount: 0,
+			stateInfo: { state: 0, stateTargetUserId: '', nextState: 0, nextStateAt: '0' },
+			bbangCount: 0,
+		} as CharacterData;
+
+		// 기본 동기화 동작 설정
+		mockGetUserFromRoom.mockReturnValue(mockUser);
+		mockUpdateCharacterFromRoom.mockImplementation(() => {});
 	});
 
-	describe('1. 기본 장착 로직', () => {
-		it('스텔스 장치를 성공적으로 장착해야 함', async () => {
-			// Given
-			const roomId = 1;
-			const userId = 'user1';
+	it('성공적으로 스텔스 장치를 장착하고 true를 반환해야 합니다', () => {
+		mockUser.character!.equips = [];
 
-			const mockUser = {
-				id: userId,
-				nickname: '테스트유저',
-				character: {
-					hp: 5,
-					equips: [], // 빈 장비 목록
-					debuffs: [],
-					handCards: [],
-					bbangCount: 0,
-					handCardsCount: 0,
-					characterType: 1,
-					roleType: 1,
-					weapon: 0,
-					stateInfo: {
-						state: CharacterStateType.NONE_CHARACTER_STATE,
-						nextState: CharacterStateType.NONE_CHARACTER_STATE,
-						nextStateAt: '0',
-						stateTargetUserId: '0',
-					},
-				},
-			};
+		// Act
+		const result = cardStealthSuitEffect(ROOM_ID, USER_ID);
 
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-			mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
-
-			// When
-			await cardStealthSuitEffect(roomId, userId);
-
-			// Then
-			expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
-			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
-				...mockUser.character,
-				equips: [CardType.STEALTH_SUIT], // 스텔스 장치가 장착됨
-			});
-		});
-
-		it('targetUserId는 무시되어야 함 (자신에게만 적용)', async () => {
-			// Given
-			const roomId = 1;
-			const userId = 'user1';
-
-			const mockUser = {
-				id: userId,
-				nickname: '테스트유저',
-				character: {
-					hp: 5,
-					equips: [],
-					debuffs: [],
-					handCards: [],
-					bbangCount: 0,
-					handCardsCount: 0,
-					characterType: 1,
-					roleType: 1,
-					weapon: 0,
-					stateInfo: {
-						state: CharacterStateType.NONE_CHARACTER_STATE,
-						nextState: CharacterStateType.NONE_CHARACTER_STATE,
-						nextStateAt: '0',
-						stateTargetUserId: '0',
-					},
-				},
-			};
-
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-			mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
-
-			// When - targetUserId 없이 호출 (함수 시그니처에 targetUserId가 없음)
-			await cardStealthSuitEffect(roomId, userId);
-
-			// Then
-			expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
-			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
-				...mockUser.character,
-				equips: [CardType.STEALTH_SUIT],
-			});
-		});
+		// Assert
+		expect(result).toBe(true);
+		expect(mockUser.character!.equips).toEqual([CardType.STEALTH_SUIT]);
+		expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(ROOM_ID, USER_ID, mockUser.character);
 	});
 
-	describe('2. 중복 착용 방지 및 교체 로직', () => {
-		it('이미 스텔스 장치를 착용한 경우 첫 번째만 교체해야 함', async () => {
-			// Given
-			const roomId = 1;
-			const userId = 'user1';
+	it('이미 스텔스 장치를 가지고 있다면, 교체하고 true를 반환해야 합니다', () => {
+		mockUser.character!.equips = [CardType.SHIELD, CardType.STEALTH_SUIT, CardType.VACCINE];
 
-			const mockUser = {
-				id: userId,
-				nickname: '테스트유저',
-				character: {
-					hp: 5,
-					equips: [CardType.STEALTH_SUIT, CardType.SHIELD], // 이미 스텔스 장치 착용
-					debuffs: [],
-					handCards: [],
-					bbangCount: 0,
-					handCardsCount: 0,
-					characterType: 1,
-					roleType: 1,
-					weapon: 0,
-					stateInfo: {
-						state: CharacterStateType.NONE_CHARACTER_STATE,
-						nextState: CharacterStateType.NONE_CHARACTER_STATE,
-						nextStateAt: '0',
-						stateTargetUserId: '0',
-					},
-				},
-			};
+		// Act
+		const result = cardStealthSuitEffect(ROOM_ID, USER_ID);
 
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-			mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
-
-			// When
-			await cardStealthSuitEffect(roomId, userId);
-
-			// Then
-			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
-				...mockUser.character,
-				equips: [CardType.SHIELD, CardType.STEALTH_SUIT], // 첫 번째 스텔스 장치 제거 후 새로 추가
-			});
-		});
-
-		it('여러 개의 스텔스 장치가 있는 경우 첫 번째만 교체해야 함', async () => {
-			// Given
-			const roomId = 1;
-			const userId = 'user1';
-
-			const mockUser = {
-				id: userId,
-				nickname: '테스트유저',
-				character: {
-					hp: 5,
-					equips: [CardType.STEALTH_SUIT, CardType.SHIELD, CardType.STEALTH_SUIT], // 스텔스 장치 2개
-					debuffs: [],
-					handCards: [],
-					bbangCount: 0,
-					handCardsCount: 0,
-					characterType: 1,
-					roleType: 1,
-					weapon: 0,
-					stateInfo: {
-						state: CharacterStateType.NONE_CHARACTER_STATE,
-						nextState: CharacterStateType.NONE_CHARACTER_STATE,
-						nextStateAt: '0',
-						stateTargetUserId: '0',
-					},
-				},
-			};
-
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-			mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
-
-			// When
-			await cardStealthSuitEffect(roomId, userId);
-
-			// Then
-			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
-				...mockUser.character,
-				equips: [CardType.SHIELD, CardType.STEALTH_SUIT, CardType.STEALTH_SUIT], // 첫 번째만 제거
-			});
-		});
-
-		it('스텔스 장치가 없는 경우 새로 장착해야 함', async () => {
-			// Given
-			const roomId = 1;
-			const userId = 'user1';
-
-			const mockUser = {
-				id: userId,
-				nickname: '테스트유저',
-				character: {
-					hp: 5,
-					equips: [CardType.SHIELD, CardType.VACCINE], // 스텔스 장치 없음
-					debuffs: [],
-					handCards: [],
-					bbangCount: 0,
-					handCardsCount: 0,
-					characterType: 1,
-					roleType: 1,
-					weapon: 0,
-					stateInfo: {
-						state: CharacterStateType.NONE_CHARACTER_STATE,
-						nextState: CharacterStateType.NONE_CHARACTER_STATE,
-						nextStateAt: '0',
-						stateTargetUserId: '0',
-					},
-				},
-			};
-
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-			mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
-
-			// When
-			await cardStealthSuitEffect(roomId, userId);
-
-			// Then
-			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
-				...mockUser.character,
-				equips: [CardType.SHIELD, CardType.VACCINE, CardType.STEALTH_SUIT], // 새로 추가
-			});
-		});
+		// Assert
+		expect(result).toBe(true);
+		// 원래의 슈트가 제거되고 끝에 새로운 슈트가 추가됩니다
+		expect(mockUser.character!.equips).toEqual([CardType.SHIELD, CardType.VACCINE, CardType.STEALTH_SUIT]);
+		expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(1);
 	});
 
-	describe('3. 유효성 검증', () => {
-		it('사용자를 찾을 수 없으면 아무것도 하지 않아야 함', async () => {
-			// Given
-			const roomId = 1;
-			const userId = 'nonexistent_user';
-
-			mockGetUserFromRoom.mockResolvedValue(null);
-
-			// When
-			await cardStealthSuitEffect(roomId, userId);
-
-			// Then
-			expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
-			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+	it('유저를 찾을 수 없으면 false를 반환해야 합니다', () => {
+		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+		const notFoundError = new Error('User not found');
+		mockGetUserFromRoom.mockImplementation(() => {
+			throw notFoundError;
 		});
 
-		it('사용자 캐릭터 정보가 없으면 아무것도 하지 않아야 함', async () => {
-			// Given
-			const roomId = 1;
-			const userId = 'user1';
+		// Act
+		const result = cardStealthSuitEffect(ROOM_ID, USER_ID);
 
-			const mockUser = {
-				id: userId,
-				nickname: '테스트유저',
-				character: undefined, // 캐릭터 정보 없음
-			};
-
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-
-			// When
-			await cardStealthSuitEffect(roomId, userId);
-
-			// Then
-			expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
-			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
-		});
-
-		it('사용자 객체 자체가 없으면 아무것도 하지 않아야 함', async () => {
-			// Given
-			const roomId = 1;
-			const userId = 'user1';
-
-			const mockUser = {
-				id: userId,
-				nickname: '테스트유저',
-				// character 속성 자체가 없음
-			};
-
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-
-			// When
-			await cardStealthSuitEffect(roomId, userId);
-
-			// Then
-			expect(mockGetUserFromRoom).toHaveBeenCalledWith(roomId, userId);
-			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
-		});
+		// Assert
+		expect(result).toBe(false);
+		expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+		expect(consoleErrorSpy).toHaveBeenCalledWith('[스텔스 장치] 처리 중 오류 발생:', notFoundError);
+		consoleErrorSpy.mockRestore();
 	});
 
-	describe('4. 에러 처리', () => {
-		it('Redis 업데이트 실패 시 에러를 로깅해야 함', async () => {
-			// Given
-			const roomId = 1;
-			const userId = 'user1';
+	it('유저의 캐릭터 정보가 없으면 false를 반환해야 합니다', () => {
+		const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+		mockUser.character = undefined;
 
-			const mockUser = {
-				id: userId,
-				nickname: '테스트유저',
-				character: {
-					hp: 5,
-					equips: [],
-					debuffs: [],
-					handCards: [],
-					bbangCount: 0,
-					handCardsCount: 0,
-					characterType: 1,
-					roleType: 1,
-					weapon: 0,
-					stateInfo: {
-						state: CharacterStateType.NONE_CHARACTER_STATE,
-						nextState: CharacterStateType.NONE_CHARACTER_STATE,
-						nextStateAt: '0',
-						stateTargetUserId: '0',
-					},
-				},
-			};
+		// Act
+		const result = cardStealthSuitEffect(ROOM_ID, USER_ID);
 
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-			mockUpdateCharacterFromRoom.mockRejectedValue(new Error('Redis connection failed'));
-
-			// 콘솔 에러를 모킹하여 에러 로깅 확인
-			const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-			// When
-			await cardStealthSuitEffect(roomId, userId);
-
-			// Then
-			expect(consoleSpy).toHaveBeenCalledWith(
-				'[스텔스 장치] Redis 업데이트 실패:',
-				expect.any(Error),
-			);
-
-			// 정리
-			consoleSpy.mockRestore();
-		});
-
-		it('성공 시 로그를 출력해야 함', async () => {
-			// Given
-			const roomId = 1;
-			const userId = 'user1';
-
-			const mockUser = {
-				id: userId,
-				nickname: '테스트유저',
-				character: {
-					hp: 5,
-					equips: [],
-					debuffs: [],
-					handCards: [],
-					bbangCount: 0,
-					handCardsCount: 0,
-					characterType: 1,
-					roleType: 1,
-					weapon: 0,
-					stateInfo: {
-						state: CharacterStateType.NONE_CHARACTER_STATE,
-						nextState: CharacterStateType.NONE_CHARACTER_STATE,
-						nextStateAt: '0',
-						stateTargetUserId: '0',
-					},
-				},
-			};
-
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-			mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
-
-			// 콘솔 로그를 모킹하여 로그 출력 확인
-			const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-
-			// When
-			await cardStealthSuitEffect(roomId, userId);
-
-			// Then
-			expect(consoleSpy).toHaveBeenCalledWith(
-				'[스텔스 장치] 테스트유저이 스텔스 장치를 장착했습니다.',
-			);
-
-			// 정리
-			consoleSpy.mockRestore();
-		});
+		// Assert
+		expect(result).toBe(false);
+		expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+		expect(consoleWarnSpy).toHaveBeenCalledWith(`[스텔스 장치] 유저의 캐릭터 정보가 없습니다: ${USER_ID}`);
+		consoleWarnSpy.mockRestore();
 	});
 
-	describe('5. 통합 시나리오 테스트', () => {
-		it('복잡한 장비 상황에서도 올바르게 작동해야 함', async () => {
-			// Given
-			const roomId = 1;
-			const userId = 'user1';
-
-			const mockUser = {
-				id: userId,
-				nickname: '테스트유저',
-				character: {
-					hp: 3,
-					equips: [CardType.SHIELD, CardType.STEALTH_SUIT, CardType.VACCINE], // 다양한 장비 착용 (기존 스텔스 장치 포함)
-					debuffs: [CardType.SATELLITE_TARGET],
-					handCards: [{ type: CardType.BBANG, count: 2 }],
-					bbangCount: 1,
-					handCardsCount: 2,
-					characterType: 2,
-					roleType: 3,
-					weapon: CardType.HAND_GUN,
-					stateInfo: {
-						state: CharacterStateType.BBANG_TARGET,
-						nextState: CharacterStateType.NONE_CHARACTER_STATE,
-						nextStateAt: String(Date.now() + 5000),
-						stateTargetUserId: '123',
-					},
-				},
-			};
-
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-			mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
-
-			// When
-			await cardStealthSuitEffect(roomId, userId);
-
-			// Then
-			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, {
-				...mockUser.character,
-				equips: [CardType.SHIELD, CardType.VACCINE, CardType.STEALTH_SUIT], // 기존 스텔스 장치 제거 후 새로 추가
-			});
+	it('캐릭터 정보 업데이트에 실패하면 false를 반환해야 합니다', () => {
+		const dbError = new Error('DB update failed');
+		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+		mockUpdateCharacterFromRoom.mockImplementation(() => {
+			throw dbError;
 		});
+
+		// Act
+		const result = cardStealthSuitEffect(ROOM_ID, USER_ID);
+
+		// Assert
+		expect(result).toBe(false);
+		expect(consoleErrorSpy).toHaveBeenCalledWith('[스텔스 장치] 처리 중 오류 발생:', dbError);
+		consoleErrorSpy.mockRestore();
 	});
 });


### PR DESCRIPTION
##내용
```typescript
위성 타겟 효과 테스트
 cardStealthSuitEffect
    √ 성공적으로 스텔스 장치를 장착하고 true를 반환해야 합니다 (20 ms)
    √ 이미 스텔스 장치를 가지고 있다면, 교체하고 true를 반환해야 합니다 (2 ms)
    √ 유저를 찾을 수 없으면 false를 반환해야 합니다 (1 ms)
    √ 유저의 캐릭터 정보가 없으면 false를 반환해야 합니다 (1 ms)
    √ 캐릭터 정보 업데이트에 실패하면 false를 반환해야 합니다 (1 ms)
``` 

다른 테스트코드들이 성공결과로 에러메세지를 결과창에 표시하는것을 안나오도록 수정
spyOn과 mockimplementation를 활용해 에러메세지를 포착하고 빈객체를 나타내는 방법 활용

##추가내용
데스매치 테스트코드에서 타입스크립트 에러 수정
의도적으로 null값을 준것을 타입스크립트가 에러로 인식해 as any를 사용해 수정