### PR TITLE
Fix/test fixes/jajeun

### DIFF
--- a/game.server/src/card/test/card.win_lottery.effect.test.ts
+++ b/game.server/src/card/test/card.win_lottery.effect.test.ts
@@ -1,285 +1,256 @@
-import cardWinLotteryEffect from '../card.win_lottery.effect.js';
-import { getUserFromRoom, updateCharacterFromRoom } from '../../utils/redis.util.js';
-import { drawDeck } from '../../managers/card.manager.js';
-import { CardType, CharacterType, RoleType } from '../../generated/common/enums.js';
-import { CharacterData } from '../../generated/common/types.js';
+import cardWinLotteryEffect from '../card.win_lottery.effect';
+import * as roomUtils from '../../utils/room.utils';
+import * as cardManager from '../../managers/card.manager';
+import { CharacterType, RoleType, CardType } from '../../generated/common/enums';
+import { User } from '../../models/user.model';
 
-// Mock dependencies
-jest.mock('../../utils/redis.util.js');
-jest.mock('../../managers/card.manager.js');
+jest.mock('../../utils/room.utils');
+jest.mock('../../managers/card.manager');
 
-const mockGetUserFromRoom = getUserFromRoom as jest.MockedFunction<typeof getUserFromRoom>;
-const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.MockedFunction<
-	typeof updateCharacterFromRoom
->;
-const mockDrawDeck = drawDeck as jest.MockedFunction<typeof drawDeck>;
+const mockGetUserFromRoom = jest.spyOn(roomUtils, 'getUserFromRoom');
+const mockUpdateCharacterFromRoom = jest.spyOn(roomUtils, 'updateCharacterFromRoom');
+const mockDrawDeck = jest.spyOn(cardManager, 'drawDeck');
+
+beforeAll(() => {
+	jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterAll(() => {
+	jest.restoreAllMocks();
+});
 
 describe('cardWinLotteryEffect', () => {
 	const roomId = 1;
-	const userId = 'user123';
+	const userId = 'user1';
 
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
 
+	const createMockCharacter = (handCards: Array<{ type: CardType; count: number }> = []) => ({
+		characterType: CharacterType.RED,
+		roleType: RoleType.TARGET,
+		hp: 3,
+		weapon: 0,
+		equips: [],
+		debuffs: [],
+		handCards,
+		bbangCount: 0,
+		handCardsCount: handCards.reduce((total, card) => total + card.count, 0),
+	});
+
 	describe('유효성 검증', () => {
-		it('사용자가 없으면 아무것도 하지 않음', async () => {
-			mockGetUserFromRoom.mockResolvedValue(null);
+		it('사용자가 없으면 함수가 종료된다', () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			mockGetUserFromRoom.mockReturnValue(null);
 
-			await cardWinLotteryEffect(roomId, userId);
+			const result = cardWinLotteryEffect(roomId, userId);
 
+			expect(result).toBe(false);
 			expect(mockDrawDeck).not.toHaveBeenCalled();
 			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
 		});
 
-		it('사용자 캐릭터가 없으면 아무것도 하지 않음', async () => {
-			mockGetUserFromRoom.mockResolvedValue({
+		it('사용자의 캐릭터가 없으면 함수가 종료된다', () => {
+			mockGetUserFromRoom.mockReturnValue({
 				id: userId,
-				nickname: '테스트유저',
-				character: undefined,
+				nickname: 'testUser',
+				// character 속성이 없음
 			});
 
-			await cardWinLotteryEffect(roomId, userId);
+			const result = cardWinLotteryEffect(roomId, userId);
 
+			expect(result).toBe(false);
 			expect(mockDrawDeck).not.toHaveBeenCalled();
 			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+		});
+
+		it('덱에 카드가 없으면 함수가 종료된다', () => {
+			const mockCharacter = createMockCharacter();
+			mockGetUserFromRoom.mockReturnValue({
+				id: userId,
+				nickname: 'testUser',
+				character: mockCharacter,
+			});
+
+			mockDrawDeck.mockReturnValue([]);
+
+			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+			const result = cardWinLotteryEffect(roomId, userId);
+
+			expect(result).toBe(false);
+			expect(consoleSpy).toHaveBeenCalledWith('[복권 당첨] testUser: 덱에 카드가 없습니다.');
+			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
+
+			consoleSpy.mockRestore();
 		});
 	});
 
 	describe('카드 획득 로직', () => {
-		const mockUser = {
-			id: userId,
-			nickname: '테스트유저',
-			character: {
-				characterType: CharacterType.RED,
-				roleType: RoleType.NONE_ROLE,
-				hp: 3,
-				weapon: 0,
-				stateInfo: undefined,
-				equips: [],
-				debuffs: [],
-				handCards: [
-					{ type: CardType.BBANG, count: 1 }, // 기존 카드
-					{ type: CardType.SHIELD, count: 1 },
-				],
-				bbangCount: 1,
-				handCardsCount: 2,
-			} as CharacterData,
-		};
-
-		it('덱에서 카드 3장을 뽑아서 핸드에 추가', async () => {
-			const newCardTypes = [CardType.VACCINE, CardType.CALL_119, CardType.DEATH_MATCH]; // 새로운 카드 타입들
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-			mockDrawDeck.mockReturnValue(newCardTypes);
-			mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
-
-			await cardWinLotteryEffect(roomId, userId);
-
-			expect(mockDrawDeck).toHaveBeenCalledWith(roomId, 3);
-			expect(mockUser.character.handCards).toHaveLength(5); // 기존 2장 + 새로 3장
-			expect(mockUser.character.handCards).toContainEqual({ type: CardType.VACCINE, count: 1 });
-			expect(mockUser.character.handCards).toContainEqual({ type: CardType.CALL_119, count: 1 });
-			expect(mockUser.character.handCards).toContainEqual({ type: CardType.DEATH_MATCH, count: 1 });
-			expect(mockUser.character.handCardsCount).toBe(5); // handCardsCount 업데이트 확인
-			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, mockUser.character);
-		});
-
-		it('같은 타입의 카드가 이미 있으면 count 증가', async () => {
-			const mockUserWithExistingCards = {
+		it('새로운 카드 3장을 획득한다', () => {
+			const mockCharacter = createMockCharacter([]);
+			mockGetUserFromRoom.mockReturnValue({
 				id: userId,
-				nickname: '테스트유저',
-				character: {
-					characterType: CharacterType.RED,
-					roleType: RoleType.NONE_ROLE,
-					hp: 3,
-					weapon: 0,
-					stateInfo: undefined,
-					equips: [],
-					debuffs: [],
-					handCards: [
-						{ type: CardType.BBANG, count: 2 }, // 기존에 2장
-						{ type: CardType.SHIELD, count: 1 },
-					],
-					bbangCount: 1,
-					handCardsCount: 3,
-				} as CharacterData,
-			};
-
-			const newCardTypes = [CardType.BBANG, CardType.VACCINE]; // BBANG은 중복, VACCINE은 새로
-			mockGetUserFromRoom.mockResolvedValue(mockUserWithExistingCards);
-			mockDrawDeck.mockReturnValue(newCardTypes);
-			mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
-
-			await cardWinLotteryEffect(roomId, userId);
-
-			// BBANG은 count가 2에서 3으로 증가
-			const bbangCard = mockUserWithExistingCards.character.handCards.find(
-				(card) => card.type === CardType.BBANG,
-			);
-			expect(bbangCard?.count).toBe(3);
-
-			// VACCINE은 새로 추가
-			expect(mockUserWithExistingCards.character.handCards).toContainEqual({
-				type: CardType.VACCINE,
-				count: 1,
+				nickname: 'testUser',
+				character: mockCharacter,
 			});
 
-			// 총 카드 개수는 4개 (BBANG 3장 + SHIELD 1장 + VACCINE 1장)
-			expect(mockUserWithExistingCards.character.handCardsCount).toBe(5);
-		});
+			const newCards = [CardType.BBANG, CardType.SHIELD, CardType.BOMB];
+			mockDrawDeck.mockReturnValue(newCards);
 
-		it('덱에 카드가 없으면 아무것도 하지 않음', async () => {
-			const mockUserEmptyDeck = {
-				id: userId,
-				nickname: '테스트유저',
-				character: {
-					characterType: CharacterType.RED,
-					roleType: RoleType.NONE_ROLE,
-					hp: 3,
-					weapon: 0,
-					stateInfo: undefined,
-					equips: [],
-					debuffs: [],
-					handCards: [
-						{ type: CardType.BBANG, count: 1 },
-						{ type: CardType.SHIELD, count: 1 },
-					],
-					bbangCount: 1,
-					handCardsCount: 2,
-				} as CharacterData,
-			};
+			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
-			mockGetUserFromRoom.mockResolvedValue(mockUserEmptyDeck);
-			mockDrawDeck.mockReturnValue([]);
+			const result = cardWinLotteryEffect(roomId, userId);
 
-			await cardWinLotteryEffect(roomId, userId);
-
-			expect(mockUserEmptyDeck.character.handCards).toHaveLength(2); // 기존 카드만 유지
-			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
-		});
-
-		it('덱에 카드가 3장 미만이면 있는 만큼만 획득', async () => {
-			const mockUserPartialDeck = {
-				id: userId,
-				nickname: '테스트유저',
-				character: {
-					characterType: CharacterType.RED,
-					roleType: RoleType.NONE_ROLE,
-					hp: 3,
-					weapon: 0,
-					stateInfo: undefined,
-					equips: [],
-					debuffs: [],
-					handCards: [
-						{ type: CardType.BBANG, count: 1 },
-						{ type: CardType.SHIELD, count: 1 },
-					],
-					bbangCount: 1,
-					handCardsCount: 2,
-				} as CharacterData,
-			};
-
-			const newCardTypes = [CardType.VACCINE, CardType.CALL_119]; // 2장만 획득
-			mockGetUserFromRoom.mockResolvedValue(mockUserPartialDeck);
-			mockDrawDeck.mockReturnValue(newCardTypes);
-			mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
-
-			await cardWinLotteryEffect(roomId, userId);
-
-			expect(mockUserPartialDeck.character.handCards).toHaveLength(4); // 기존 2장 + 새로 2장
-			expect(mockUserPartialDeck.character.handCardsCount).toBe(4); // handCardsCount 업데이트 확인
-			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(
-				roomId,
-				userId,
-				mockUserPartialDeck.character,
+			expect(result).toBe(true);
+			expect(mockDrawDeck).toHaveBeenCalledWith(roomId, 3);
+			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, mockCharacter);
+			expect(mockCharacter.handCards).toEqual([
+				{ type: CardType.BBANG, count: 1 },
+				{ type: CardType.SHIELD, count: 1 },
+				{ type: CardType.BOMB, count: 1 },
+			]);
+			expect(mockCharacter.handCardsCount).toBe(3);
+			expect(consoleSpy).toHaveBeenCalledWith(
+				'[복권 당첨] testUser이 카드 3장을 획득했습니다:',
+				'BBANG, SHIELD, BOMB',
 			);
+
+			consoleSpy.mockRestore();
+		});
+
+		it('기존 카드와 중복되면 count가 증가한다', () => {
+			const existingCards = [
+				{ type: CardType.BBANG, count: 2 },
+				{ type: CardType.SHIELD, count: 1 },
+			];
+			const mockCharacter = createMockCharacter(existingCards);
+			mockGetUserFromRoom.mockReturnValue({
+				id: userId,
+				nickname: 'testUser',
+				character: mockCharacter,
+			});
+
+			const newCards = [CardType.BBANG, CardType.SHIELD, CardType.BOMB];
+			mockDrawDeck.mockReturnValue(newCards);
+
+			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+			const result = cardWinLotteryEffect(roomId, userId);
+
+			expect(result).toBe(true);
+			expect(mockCharacter.handCards).toEqual([
+				{ type: CardType.BBANG, count: 3 },
+				{ type: CardType.SHIELD, count: 2 },
+				{ type: CardType.BOMB, count: 1 },
+			]);
+			expect(mockCharacter.handCardsCount).toBe(6);
+
+			consoleSpy.mockRestore();
+		});
+
+		it('덱에 카드가 부족하면 받을 수 있는 만큼만 받는다', () => {
+			const mockCharacter = createMockCharacter([]);
+			mockGetUserFromRoom.mockReturnValue({
+				id: userId,
+				nickname: 'testUser',
+				character: mockCharacter,
+			});
+
+			const newCards = [CardType.BBANG, CardType.SHIELD];
+			mockDrawDeck.mockReturnValue(newCards);
+
+			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+			const result = cardWinLotteryEffect(roomId, userId);
+
+			expect(result).toBe(true);
+			expect(mockCharacter.handCards).toEqual([
+				{ type: CardType.BBANG, count: 1 },
+				{ type: CardType.SHIELD, count: 1 },
+			]);
+			expect(mockCharacter.handCardsCount).toBe(2);
+			expect(consoleSpy).toHaveBeenCalledWith(
+				'[복권 당첨] testUser이 카드 2장을 획득했습니다:',
+				'BBANG, SHIELD',
+			);
+
+			consoleSpy.mockRestore();
+		});
+
+		it('같은 카드가 여러 번 나오면 count가 누적된다', () => {
+			const mockCharacter = createMockCharacter([]);
+			mockGetUserFromRoom.mockReturnValue({
+				id: userId,
+				nickname: 'testUser',
+				character: mockCharacter,
+			});
+
+			const newCards = [CardType.BBANG, CardType.BBANG, CardType.BBANG];
+			mockDrawDeck.mockReturnValue(newCards);
+
+			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+			const result = cardWinLotteryEffect(roomId, userId);
+
+			expect(result).toBe(true);
+			expect(mockCharacter.handCards).toEqual([{ type: CardType.BBANG, count: 3 }]);
+			expect(mockCharacter.handCardsCount).toBe(3);
+
+			consoleSpy.mockRestore();
 		});
 	});
 
 	describe('에러 처리', () => {
-		const mockUser = {
-			id: userId,
-			nickname: '테스트유저',
-			character: {
-				characterType: CharacterType.RED,
-				roleType: RoleType.NONE_ROLE,
-				hp: 3,
-				weapon: 0,
-				stateInfo: undefined,
-				equips: [],
-				debuffs: [],
-				handCards: [],
-				bbangCount: 1,
-				handCardsCount: 0,
-			} as CharacterData,
-		};
+		it('사용자 조회에서 에러가 발생하면 에러가 전파된다', () => {
+			mockGetUserFromRoom.mockImplementation(() => {
+				throw new Error('User not found');
+			});
 
-		it('Redis 업데이트 실패 시 에러 로깅', async () => {
-			const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-			const newCardTypes = [CardType.VACCINE, CardType.CALL_119, CardType.DEATH_MATCH];
+			expect(() => cardWinLotteryEffect(roomId, userId)).toThrow('User not found');
+		});
 
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-			mockDrawDeck.mockReturnValue(newCardTypes);
-			mockUpdateCharacterFromRoom.mockRejectedValue(new Error('Redis 연결 실패'));
+		it('updateCharacterFromRoom에서 에러가 발생하면 에러가 처리된다', () => {
+			const mockCharacter = createMockCharacter([]);
+			mockGetUserFromRoom.mockReturnValue({
+				id: userId,
+				nickname: 'testUser',
+				character: mockCharacter,
+			});
 
-			await cardWinLotteryEffect(roomId, userId);
+			mockDrawDeck.mockReturnValue([CardType.BBANG, CardType.SHIELD, CardType.BOMB]);
 
-			expect(consoleSpy).toHaveBeenCalledWith(
+			mockUpdateCharacterFromRoom.mockImplementation(() => {
+				throw new Error('Update error');
+			});
+
+			const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+			const result = cardWinLotteryEffect(roomId, userId);
+
+			expect(result).toBe(false);
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
 				'[복권 당첨] Redis 업데이트 실패:',
 				expect.any(Error),
 			);
 
-			consoleSpy.mockRestore();
-		});
-	});
-
-	describe('로깅', () => {
-		const mockUser = {
-			id: userId,
-			nickname: '테스트유저',
-			character: {
-				characterType: CharacterType.RED,
-				roleType: RoleType.NONE_ROLE,
-				hp: 3,
-				weapon: 0,
-				stateInfo: undefined,
-				equips: [],
-				debuffs: [],
-				handCards: [],
-				bbangCount: 1,
-				handCardsCount: 0,
-			} as CharacterData,
-		};
-
-		it('카드 획득 성공 시 로그 출력', async () => {
-			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
-			const newCardTypes = [CardType.VACCINE, CardType.CALL_119, CardType.DEATH_MATCH];
-
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-			mockDrawDeck.mockReturnValue(newCardTypes);
-			mockUpdateCharacterFromRoom.mockResolvedValue(undefined);
-
-			await cardWinLotteryEffect(roomId, userId);
-
-			expect(consoleSpy).toHaveBeenCalledWith(
-				'[복권 당첨] 테스트유저이 카드 3장을 획득했습니다:',
-				'VACCINE, CALL_119, DEATH_MATCH',
-			);
-
-			consoleSpy.mockRestore();
+			consoleErrorSpy.mockRestore();
 		});
 
-		it('덱에 카드가 없을 때 로그 출력', async () => {
-			const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+		it('drawDeck에서 에러가 발생하면 에러가 전파된다', () => {
+			const mockCharacter = createMockCharacter([]);
+			mockGetUserFromRoom.mockReturnValue({
+				id: userId,
+				nickname: 'testUser',
+				character: mockCharacter,
+			});
 
-			mockGetUserFromRoom.mockResolvedValue(mockUser);
-			mockDrawDeck.mockReturnValue([]);
+			mockDrawDeck.mockImplementation(() => {
+				throw new Error('Deck error');
+			});
 
-			await cardWinLotteryEffect(roomId, userId);
-
-			expect(consoleSpy).toHaveBeenCalledWith('[복권 당첨] 테스트유저: 덱에 카드가 없습니다.');
-
-			consoleSpy.mockRestore();
+			expect(() => cardWinLotteryEffect(roomId, userId)).toThrow('Deck error');
 		});
 	});
 });

--- a/game.server/src/useCase/position.update/position.update.usecase.test.ts
+++ b/game.server/src/useCase/position.update/position.update.usecase.test.ts
@@ -1,0 +1,382 @@
+import positionUpdateUseCase from './position.update.usecase';
+import { C2SPositionUpdateRequest } from '../../generated/packet/game_actions';
+import { GameSocket } from '../../type/game.socket';
+import { CharacterPositionData } from '../../generated/common/types';
+import { notificationCharacterPosition } from '../../managers/game.manager';
+
+jest.mock('../../managers/game.manager', () => ({
+	notificationCharacterPosition: new Map(),
+}));
+
+const mockNotificationCharacterPosition = notificationCharacterPosition as unknown as jest.Mocked<Map<string, Map<string, CharacterPositionData>>>;
+
+beforeAll(() => {
+	jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterAll(() => {
+	jest.restoreAllMocks();
+});
+
+describe('positionUpdateUseCase', () => {
+	const roomId = '1';
+	const userId = 'user1';
+	const validX = 100.5;
+	const validY = 200.3;
+
+	beforeEach(() => {
+		mockNotificationCharacterPosition.clear();
+		const roomMap = new Map<string, CharacterPositionData>();
+		mockNotificationCharacterPosition.set(roomId, roomMap);
+	});
+
+	describe('유효성 검증', () => {
+		it('소켓에 userId가 없으면 함수가 실패한다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: undefined,
+				roomId: roomId,
+			} as GameSocket;
+
+			const mockRequest: C2SPositionUpdateRequest = {
+				x: validX,
+				y: validY,
+			};
+
+			const result = await positionUpdateUseCase(mockSocket, mockRequest);
+
+			expect(result).toBe(false);
+		});
+
+		it('소켓에 roomId가 없으면 함수가 실패한다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: userId,
+				roomId: undefined,
+			} as GameSocket;
+
+			const mockRequest: C2SPositionUpdateRequest = {
+				x: validX,
+				y: validY,
+			};
+
+			const result = await positionUpdateUseCase(mockSocket, mockRequest);
+
+			expect(result).toBe(false);
+		});
+
+		it('X 좌표가 숫자가 아니면 함수가 실패한다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: userId,
+				roomId: roomId,
+			} as GameSocket;
+
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockRequest = {
+				x: 'invalid',
+				y: validY,
+			} as C2SPositionUpdateRequest;
+
+			const result = await positionUpdateUseCase(mockSocket, mockRequest);
+
+			expect(result).toBe(false);
+		});
+
+		it('Y 좌표가 숫자가 아니면 함수가 실패한다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: userId,
+				roomId: roomId,
+			} as GameSocket;
+
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockRequest = {
+				x: validX,
+				y: null,
+			} as C2SPositionUpdateRequest;
+
+			const result = await positionUpdateUseCase(mockSocket, mockRequest);
+
+			expect(result).toBe(false);
+		});
+
+		it('X와 Y 좌표 모두 유효하지 않으면 함수가 실패한다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: userId,
+				roomId: roomId,
+			} as GameSocket;
+
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockRequest = {
+				x: undefined,
+				y: 'invalid',
+			} as C2SPositionUpdateRequest;
+
+			const result = await positionUpdateUseCase(mockSocket, mockRequest);
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('위치 업데이트 로직', () => {
+		it('유효한 좌표로 위치가 업데이트된다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: userId,
+				roomId: roomId,
+			} as GameSocket;
+
+			const mockRequest: C2SPositionUpdateRequest = {
+				x: validX,
+				y: validY,
+			};
+
+			const result = await positionUpdateUseCase(mockSocket, mockRequest);
+
+			expect(result).toBe(true);
+			
+			const roomMap = mockNotificationCharacterPosition.get(roomId);
+			expect(roomMap).toBeDefined();
+			
+			const positionData = roomMap!.get(userId);
+			expect(positionData).toBeDefined();
+			expect(positionData).toEqual({
+				id: userId,
+				x: validX,
+				y: validY,
+			});
+		});
+
+		it('정수 좌표로도 위치가 업데이트된다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: userId,
+				roomId: roomId,
+			} as GameSocket;
+
+			const mockRequest: C2SPositionUpdateRequest = {
+				x: 50,
+				y: 75,
+			};
+
+			const result = await positionUpdateUseCase(mockSocket, mockRequest);
+
+			expect(result).toBe(true);
+			
+			const roomMap = mockNotificationCharacterPosition.get(roomId);
+			const positionData = roomMap!.get(userId);
+			expect(positionData).toEqual({
+				id: userId,
+				x: 50,
+				y: 75,
+			});
+		});
+
+		it('음수 좌표로도 위치가 업데이트된다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: userId,
+				roomId: roomId,
+			} as GameSocket;
+
+			const mockRequest: C2SPositionUpdateRequest = {
+				x: -100.5,
+				y: -200.3,
+			};
+
+			const result = await positionUpdateUseCase(mockSocket, mockRequest);
+
+			expect(result).toBe(true);
+			
+			const roomMap = mockNotificationCharacterPosition.get(roomId);
+			const positionData = roomMap!.get(userId);
+			expect(positionData).toEqual({
+				id: userId,
+				x: -100.5,
+				y: -200.3,
+			});
+		});
+
+		it('0 좌표로도 위치가 업데이트된다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: userId,
+				roomId: roomId,
+			} as GameSocket;
+
+			const mockRequest: C2SPositionUpdateRequest = {
+				x: 0,
+				y: 0,
+			};
+
+			const result = await positionUpdateUseCase(mockSocket, mockRequest);
+
+			expect(result).toBe(true);
+			
+			const roomMap = mockNotificationCharacterPosition.get(roomId);
+			const positionData = roomMap!.get(userId);
+			expect(positionData).toEqual({
+				id: userId,
+				x: 0,
+				y: 0,
+			});
+		});
+
+		it('기존 위치를 새로운 위치로 덮어쓸 수 있다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: userId,
+				roomId: roomId,
+			} as GameSocket;
+
+			const firstRequest: C2SPositionUpdateRequest = {
+				x: 100,
+				y: 200,
+			};
+
+			const firstResult = await positionUpdateUseCase(mockSocket, firstRequest);
+
+			expect(firstResult).toBe(true);
+			
+			let roomMap = mockNotificationCharacterPosition.get(roomId);
+			let positionData = roomMap!.get(userId);
+			expect(positionData).toEqual({
+				id: userId,
+				x: 100,
+				y: 200,
+			});
+
+			const secondRequest: C2SPositionUpdateRequest = {
+				x: 300,
+				y: 400,
+			};
+
+			const secondResult = await positionUpdateUseCase(mockSocket, secondRequest);
+
+			expect(secondResult).toBe(true);
+			
+			roomMap = mockNotificationCharacterPosition.get(roomId);
+			positionData = roomMap!.get(userId);
+			expect(positionData).toEqual({
+				id: userId,
+				x: 300,
+				y: 400,
+			});
+		});
+
+		it('같은 방의 여러 사용자 위치를 독립적으로 관리할 수 있다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const user1Socket = {
+				userId: 'user1',
+				roomId: roomId,
+			} as GameSocket;
+
+			// @ts-expect-error: 테스트를 위한 모킹
+			const user2Socket = {
+				userId: 'user2',
+				roomId: roomId,
+			} as GameSocket;
+
+			const user1Request: C2SPositionUpdateRequest = {
+				x: 100,
+				y: 200,
+			};
+
+			const user2Request: C2SPositionUpdateRequest = {
+				x: 300,
+				y: 400,
+			};
+
+			const user1Result = await positionUpdateUseCase(user1Socket, user1Request);
+			const user2Result = await positionUpdateUseCase(user2Socket, user2Request);
+
+			expect(user1Result).toBe(true);
+			expect(user2Result).toBe(true);
+			
+			const roomMap = mockNotificationCharacterPosition.get(roomId);
+			
+			const user1Position = roomMap!.get('user1');
+			expect(user1Position).toEqual({
+				id: 'user1',
+				x: 100,
+				y: 200,
+			});
+			
+			const user2Position = roomMap!.get('user2');
+			expect(user2Position).toEqual({
+				id: 'user2',
+				x: 300,
+				y: 400,
+			});
+		});
+	});
+
+	describe('에러 처리', () => {
+		it('방 맵이 존재하지 않으면 에러가 발생한다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: userId,
+				roomId: 'nonexistent-room',
+			} as GameSocket;
+
+			const mockRequest: C2SPositionUpdateRequest = {
+				x: validX,
+				y: validY,
+			};
+
+			await expect(positionUpdateUseCase(mockSocket, mockRequest)).rejects.toThrow();
+		});
+
+		it('매우 큰 좌표값도 처리할 수 있다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: userId,
+				roomId: roomId,
+			} as GameSocket;
+
+			const mockRequest: C2SPositionUpdateRequest = {
+				x: Number.MAX_SAFE_INTEGER,
+				y: Number.MIN_SAFE_INTEGER,
+			};
+
+			const result = await positionUpdateUseCase(mockSocket, mockRequest);
+
+			expect(result).toBe(true);
+			
+			const roomMap = mockNotificationCharacterPosition.get(roomId);
+			const positionData = roomMap!.get(userId);
+			expect(positionData).toEqual({
+				id: userId,
+				x: Number.MAX_SAFE_INTEGER,
+				y: Number.MIN_SAFE_INTEGER,
+			});
+		});
+
+		it('소수점이 많은 좌표값도 처리할 수 있다', async () => {
+			// @ts-expect-error: 테스트를 위한 모킹
+			const mockSocket = {
+				userId: userId,
+				roomId: roomId,
+			} as GameSocket;
+
+			const mockRequest: C2SPositionUpdateRequest = {
+				x: 123.4567890123456789,
+				y: 987.6543210987654321,
+			};
+
+			const result = await positionUpdateUseCase(mockSocket, mockRequest);
+
+			expect(result).toBe(true);
+			
+			const roomMap = mockNotificationCharacterPosition.get(roomId);
+			const positionData = roomMap!.get(userId);
+			expect(positionData).toEqual({
+				id: userId,
+				x: 123.4567890123456789,
+				y: 987.6543210987654321,
+			});
+		});
+	});
+});


### PR DESCRIPTION
##제목

 로터리 이펙트 및 포지션 업데이트 유즈 케이스 테스트 추가

##내용
  ```
positionUpdateUseCase
    유효성 검증
      √ 소켓에 userId가 없으면 함수가 실패한다 (3 ms)
      √ 소켓에 roomId가 없으면 함수가 실패한다 (1 ms)
      √ X 좌표가 숫자가 아니면 함수가 실패한다 (1 ms)
      √ Y 좌표가 숫자가 아니면 함수가 실패한다 (1 ms)
      √ X와 Y 좌표 모두 유효하지 않으면 함수가 실패한다 (1 ms)
    위치 업데이트 로직
      √ 유효한 좌표로 위치가 업데이트된다 (2 ms)
      √ 정수 좌표로도 위치가 업데이트된다 (1 ms)
      √ 음수 좌표로도 위치가 업데이트된다 (1 ms)
      √ 0 좌표로도 위치가 업데이트된다 (1 ms)                                           
      √ 기존 위치를 새로운 위치로 덮어쓸 수 있다                                        
      √ 같은 방의 여러 사용자 위치를 독립적으로 관리할 수 있다                          
    에러 처리                                                                           
      √ 방 맵이 존재하지 않으면 에러가 발생한다 (6 ms)                                  
      √ 매우 큰 좌표값도 처리할 수 있다 (1 ms)                                          
      √ 소수점이 많은 좌표값도 처리할 수 있다 (1 ms)                                    
                            
  cardWinLotteryEffect
    유효성 검증                                                                         
      √ 사용자가 없으면 함수가 종료된다 (4 ms)                                          
      √ 사용자의 캐릭터가 없으면 함수가 종료된다 (1 ms)                                 
      √ 덱에 카드가 없으면 함수가 종료된다 (2 ms)                                       
    카드 획득 로직                                                                      
      √ 새로운 카드 3장을 획득한다 (1 ms)                                               
      √ 기존 카드와 중복되면 count가 증가한다 (1 ms)                                    
      √ 덱에 카드가 부족하면 받을 수 있는 만큼만 받는다                                 
      √ 같은 카드가 여러 번 나오면 count가 누적된다 (2 ms)                              
    에러 처리                                                                           
      √ 사용자 조회에서 에러가 발생하면 에러가 전파된다 (12 ms)                         
      √ updateCharacterFromRoom에서 에러가 발생하면 에러가 처리된다 (1 ms)              
      √ drawDeck에서 에러가 발생하면 에러가 전파된다 (1 ms)
```                              