### PR TITLE
refactor  핸드카드 제거 로직을 개별 카드로직에 추가

### DIFF
--- a/game.server/src/card/card.absorb.effect.ts
+++ b/game.server/src/card/card.absorb.effect.ts
@@ -1,10 +1,13 @@
 // cardType = 8
 
-import { getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
+import { CardType } from '../generated/common/enums';
+import { removeCard } from '../managers/card.manager';
+import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
 
 const cardAbsorbEffect = (roomId: number, userId: string, targetUserId: string): boolean => {
 	const user = getUserFromRoom(roomId, userId);
 	const target = getUserFromRoom(roomId, targetUserId);
+	let room = getRoom(roomId)
 	// 유효성 검증
 	if (!user || !user.character || !target || !target.character) return false;
 
@@ -15,6 +18,8 @@ const cardAbsorbEffect = (roomId: number, userId: string, targetUserId: string):
 		// 대상이 카드를 가지고 있지 않으면 효과가 발동하지 않음
 		return false;
 	}
+
+	removeCard(user, room, CardType.ABSORB)
 
 	// 대상의 손에서 무작위로 카드 한 장을 선택하여 훔침
 	const randomIndex = Math.floor(Math.random() * targetHand.length);

--- a/game.server/src/card/card.auto_shield.effect.ts
+++ b/game.server/src/card/card.auto_shield.effect.ts
@@ -1,29 +1,43 @@
-import { getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
+import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
 import { CardType } from '../generated/common/enums';
+import { removeCard } from '../managers/card.manager';
 
 const cardAutoShieldEffect = (roomId: number, userId: string): boolean => {
-	const user = getUserFromRoom(roomId, userId);
-	// 유효성 검증
-	if (!user || !user.character) {
-		return false;
-	}
+	try {
+		const user = getUserFromRoom(roomId, userId);
+		const room = getRoom(roomId);
 
-	// 자동 쉴드 장착
-	if (!user.character.equips.includes(CardType.AUTO_SHIELD)) {
+		// 유효성 검증 1: 유저 및 캐릭터 존재 여부
+		if (!user || !user.character) {
+			console.warn(`[자동 방패] 유저 또는 캐릭터 정보를 찾을 수 없습니다: ${userId}`);
+			return false;
+		}
+
+		// 유효성 검증 2: 이미 자동 방패를 장착했는지 확인
+		if (user.character.equips.includes(CardType.AUTO_SHIELD)) {
+			console.log(`[자동 방패] ${user.nickname}님은 이미 자동 방패를 장착하고 있습니다.`);
+			return false;
+		}
+
+		// 조건 만족 시 카드 제거
+		removeCard(user, room, CardType.AUTO_SHIELD);
+
+		// 자동 방패 장착
 		user.character.equips.push(CardType.AUTO_SHIELD);
-	} else {
+
+		// 정보 업데이트
+		updateCharacterFromRoom(roomId, userId, user.character);
+		console.log(`[자동 방패] ${user.nickname}님이 자동 방패를 장착했습니다.`);
+		return true;
+	} catch (error) {
+		console.error(`[자동 방패] 처리 중 에러 발생:`, error);
 		return false;
 	}
-
-	// 정보 업데이트
-	updateCharacterFromRoom(roomId, userId, user.character);
-	return true;
 };
 
 // 피격 시 자동 쉴드의 25% 방어 확률을 계산하는 효과.
 export const autoShieldBlock = (): boolean => {
 	return Math.random() < 0.25;
 };
-
 
 export default cardAutoShieldEffect;

--- a/game.server/src/card/card.desert_eagle.effect.ts
+++ b/game.server/src/card/card.desert_eagle.effect.ts
@@ -1,10 +1,14 @@
 import { CardType } from '../generated/common/enums';
-import { getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
+import { removeCard } from '../managers/card.manager';
+import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
 const cardDesertEagleEffect = (roomId: number, userId: string): boolean => {
 	try {
 		const user = getUserFromRoom(roomId, userId);
+		let room = getRoom(roomId)
 		// 유효성 검증
 		if (!user || !user.character) return false;
+		
+		removeCard(user, room, CardType.DESERT_EAGLE )
 
 		// 데저트 이글 장착 (기존 무기는 덮어쓰기로 교체)
 		user.character.weapon = CardType.DESERT_EAGLE;

--- a/game.server/src/card/card.satellite_target.effect.ts
+++ b/game.server/src/card/card.satellite_target.effect.ts
@@ -3,16 +3,19 @@ import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../utils/room
 import { CardType, AnimationType } from '../generated/common/enums';
 import { playAnimationHandler } from '../handlers/play.animation.handler';
 import { checkAndEndGameIfNeeded } from '../utils/game.end.util';
+import { removeCard } from '../managers/card.manager';
 
 // 위성 타겟 카드 사용 시 디버프 추가
 const cardSatelliteTargetEffect = (
 	roomId: number,
 	userId: string,
 	targetUserId: string,
-
 ): boolean => {
 	try {
 		const target = getUserFromRoom(roomId, targetUserId);
+		const user = getUserFromRoom(roomId, userId);
+		let room = getRoom(roomId);
+
 		if (!target.character) {
 			return false;
 		}
@@ -21,6 +24,8 @@ const cardSatelliteTargetEffect = (
 		if (target.character.debuffs.includes(CardType.SATELLITE_TARGET)) {
 			return true;
 		}
+
+		removeCard(user, room, CardType.SATELLITE_TARGET);
 
 		// 디버프 추가
 		target.character.debuffs.push(CardType.SATELLITE_TARGET);
@@ -60,7 +65,6 @@ export const checkSatelliteTargetEffect = async (roomId: number) => {
 // 개별 유저의 위성 타겟 효과 처리
 const processSatelliteTargetEffect = async (roomId: number, userId: string, allUsers: any[]) => {
 	try {
-
 		const target = getUserFromRoom(roomId, userId);
 		if (!target || !target.character) return;
 
@@ -90,7 +94,6 @@ const processSatelliteTargetEffect = async (roomId: number, userId: string, allU
 			if (debuffIndex > -1) {
 				target.character.debuffs.splice(debuffIndex, 1);
 			}
-
 
 			updateCharacterFromRoom(roomId, userId, target.character);
 
@@ -129,4 +132,3 @@ const processSatelliteTargetEffect = async (roomId: number, userId: string, allU
 };
 
 export default cardSatelliteTargetEffect;
-

--- a/game.server/src/card/card.vaccine.effect.ts
+++ b/game.server/src/card/card.vaccine.effect.ts
@@ -1,9 +1,14 @@
+import { CardType } from '../generated/common/enums';
+import { removeCard } from '../managers/card.manager';
 import getMaxHp from '../utils/character.util';
-import { getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
+import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
 
 const cardVaccineEffect = (roomId: number, userId: string): boolean => {
 	try {
 		const user = getUserFromRoom(roomId, userId);
+		let room = getRoom(roomId);
+
+		if (!room) return false;
 
 		// 유효성 검증 (캐릭터 존재 여부)
 		if (!user.character) {
@@ -16,6 +21,8 @@ const cardVaccineEffect = (roomId: number, userId: string): boolean => {
 			console.log(`체력이 최대치(${maxHp})에 도달하여 더이상 회복 할 수 없습니다.`);
 			return false;
 		}
+
+		removeCard(user, room, CardType.VACCINE);
 
 		const previousHp = user.character.hp;
 		user.character.hp = Math.min(user.character.hp + 1, maxHp);

--- a/game.server/src/card/test/card.absorb.effect.test.ts
+++ b/game.server/src/card/test/card.absorb.effect.test.ts
@@ -1,14 +1,20 @@
 import { CardType } from '../../generated/common/enums';
+import { removeCard } from '../../managers/card.manager';
 import { User } from '../../models/user.model';
 import { getUserFromRoom, updateCharacterFromRoom } from '../../utils/room.utils';
 import cardAbsorbEffect from '../card.absorb.effect';
 
 // Mock dependencies
 jest.mock('../../utils/room.utils');
+jest.mock('../../managers/card.manager', () => ({
+	removeCard: jest.fn(),
+}));
 
 // Cast mocks to the correct type
 const mockGetUserFromRoom = getUserFromRoom as jest.Mock;
 const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.Mock;
+const mockRemoveCard = removeCard as jest.Mock;
+
 
 describe('cardAbsorbEffect', () => {
 	let user: User;
@@ -58,6 +64,7 @@ describe('cardAbsorbEffect', () => {
 
 	it('유저 또는 타겟을 찾을 수 없으면 false를 반환해야 한다', () => {
 		mockGetUserFromRoom.mockReturnValue(null);
+		expect(mockRemoveCard).toHaveBeenCalledTimes(0)
 		expect(cardAbsorbEffect(roomId, userId, targetId)).toBe(false);
 	});
 
@@ -65,6 +72,7 @@ describe('cardAbsorbEffect', () => {
 		target.character!.handCards = [];
 		const result = cardAbsorbEffect(roomId, userId, targetId);
 		expect(result).toBe(false);
+		expect(mockRemoveCard).toHaveBeenCalledTimes(0)
 		expect(consoleLogSpy).toHaveBeenCalled();
 		expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
 	});
@@ -78,6 +86,7 @@ describe('cardAbsorbEffect', () => {
 		const result = cardAbsorbEffect(roomId, userId, targetId);
 
 		expect(result).toBe(true);
+		expect(mockRemoveCard).toHaveBeenCalledTimes(1)
 		// Target should lose the hand gun
 		expect(target.character!.handCards.some((c) => c.type === CardType.HAND_GUN)).toBe(false);
 		// User should gain the hand gun
@@ -95,6 +104,7 @@ describe('cardAbsorbEffect', () => {
 		const result = cardAbsorbEffect(roomId, userId, targetId);
 
 		expect(result).toBe(true);
+		expect(mockRemoveCard).toHaveBeenCalledTimes(1)
 		// Target's shield count should decrease
 		expect(target.character!.handCards.find((c) => c.type === CardType.SHIELD)?.count).toBe(2);
 		// User should gain one shield

--- a/game.server/src/card/test/card.auto_shield.effect.test.ts
+++ b/game.server/src/card/test/card.auto_shield.effect.test.ts
@@ -1,74 +1,109 @@
-import { CardType } from '../../generated/common/enums';
+import { CardType, CharacterType, RoleType, RoomStateType } from '../../generated/common/enums';
+import { removeCard } from '../../managers/card.manager';
+import { Room } from '../../models/room.model';
 import { User } from '../../models/user.model';
-import { getUserFromRoom, updateCharacterFromRoom } from '../../utils/room.utils';
+import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../../utils/room.utils';
 import cardAutoShieldEffect, { autoShieldBlock } from '../card.auto_shield.effect';
+import { Character } from '../../models/character.model';
 
-// Mock dependencies
-jest.mock('../../utils/room.utils');
+// 의존성 모의(Mock) 설정
+jest.mock('../../utils/room.utils', () => ({
+	getRoom: jest.fn(),
+	getUserFromRoom: jest.fn(),
+	updateCharacterFromRoom: jest.fn(),
+}));
+jest.mock('../../managers/card.manager', () => ({
+	removeCard: jest.fn(),
+}));
 
-// Cast mocks to the correct type
+// 모의 함수(Mock Function) 정의
 const mockGetUserFromRoom = getUserFromRoom as jest.Mock;
 const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.Mock;
+const mockGetRoom = getRoom as jest.Mock;
+const mockRemoveCard = removeCard as jest.Mock;
 
 describe('cardAutoShieldEffect', () => {
-	let mockUser: User;
 	const roomId = 1;
 	const userId = 'user-1';
+	let mockRoom: Room;
+	let mockUser: User;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
 
 		mockUser = new User(userId, 'Test User');
-		mockUser.character = { hp: 4, equips: [], handCards: [] } as any;
+		mockUser.character = new Character(CharacterType.RED, RoleType.NONE_ROLE, 4, 0, [], [], [], 1, 0);
+		mockRoom = new Room(roomId, mockUser.id, 'test-room', 2, RoomStateType.INGAME, [mockUser]);
 
+		mockGetRoom.mockReturnValue(mockRoom);
 		mockGetUserFromRoom.mockReturnValue(mockUser);
 	});
 
-	// --- Validation Tests ---
+	// --- 유효성 검증 테스트 ---
 	it('유저를 찾을 수 없으면 false를 반환해야 한다', () => {
+		// 준비
 		mockGetUserFromRoom.mockReturnValue(null);
+		// 실행
 		const result = cardAutoShieldEffect(roomId, userId);
+		// 검증
 		expect(result).toBe(false);
+		expect(mockRemoveCard).not.toHaveBeenCalled();
 		expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
 	});
 
 	it('유저에게 캐릭터 정보가 없으면 false를 반환해야 한다', () => {
+		// 준비
 		mockUser.character = undefined;
+		// 실행
 		const result = cardAutoShieldEffect(roomId, userId);
+		// 검증
 		expect(result).toBe(false);
+		expect(mockRemoveCard).not.toHaveBeenCalled();
 		expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
 	});
 
-	// --- Success Scenario ---
+	// --- 성공 시나리오 ---
 	it('자동 방패를 장착하고 있지 않으면, equips에 추가하고 true를 반환해야 한다', () => {
+		// 실행
 		const result = cardAutoShieldEffect(roomId, userId);
 
+		// 검증
 		expect(result).toBe(true);
+		expect(mockRemoveCard).toHaveBeenCalledTimes(1);
 		expect(mockUser.character!.equips).toContain(CardType.AUTO_SHIELD);
 		expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, mockUser.character);
 	});
 
-	// --- Failure Scenarios ---
+	// --- 실패 시나리오 ---
 	it('이미 자동 방패를 장착하고 있으면, false를 반환해야 한다', () => {
-		// Pre-equip the auto shield
+		// 준비: 자동 방패를 미리 장착
 		mockUser.character!.equips.push(CardType.AUTO_SHIELD);
 
+		// 실행
 		const result = cardAutoShieldEffect(roomId, userId);
 
+		// 검증
 		expect(result).toBe(false);
-		// The character should not be updated again
+		expect(mockRemoveCard).not.toHaveBeenCalled();
 		expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
 	});
 
-	it('updateCharacterFromRoom에서 에러가 발생하면, 해당 에러를 그대로 발생시켜야 한다', () => {
+	it('DB 업데이트 실패 시 false를 반환해야 한다', () => {
+		// 준비
 		const dbError = new Error('Redis connection failed');
 		mockUpdateCharacterFromRoom.mockImplementation(() => {
 			throw dbError;
 		});
+		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-		expect(() => {
-			cardAutoShieldEffect(roomId, userId);
-		}).toThrow(dbError);
+		// 실행
+		const result = cardAutoShieldEffect(roomId, userId);
+
+		// 검증
+		expect(result).toBe(false);
+		expect(mockRemoveCard).toHaveBeenCalledTimes(1); // 카드 제거는 먼저 실행됨
+		expect(consoleErrorSpy).toHaveBeenCalledWith('[자동 방패] 처리 중 에러 발생:', dbError);
+		consoleErrorSpy.mockRestore();
 	});
 });
 

--- a/game.server/src/card/test/card.desert_eagle.effect.test.ts
+++ b/game.server/src/card/test/card.desert_eagle.effect.test.ts
@@ -1,34 +1,45 @@
 import cardDesertEagleEffect from '../card.desert_eagle.effect';
-import { getUserFromRoom, updateCharacterFromRoom } from '../../utils/room.utils';
+import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../../utils/room.utils';
 import { User } from '../../models/user.model';
 import {
 	CardType,
 	CharacterType,
 	RoleType,
 	CharacterStateType,
+	RoomStateType,
 } from '../../generated/common/enums';
 import { CharacterData } from '../../generated/common/types';
+import { removeCard } from '../../managers/card.manager';
+import { Room } from '../../models/room.model';
 
-// cardDesertEagleEffect 함수의 직접적인 의존성인 room.utils를 모킹합니다.
+// 의존성 모의(Mock) 설정
 jest.mock('../../utils/room.utils', () => ({
+	getRoom: jest.fn(),
 	getUserFromRoom: jest.fn(),
 	updateCharacterFromRoom: jest.fn(),
 }));
 
-// 타입스크립트와 함께 사용하기 위해 모킹된 함수를 캐스팅합니다.
+jest.mock('../../managers/card.manager', () => ({
+	removeCard: jest.fn(),
+}));
+
+// 모의 함수(Mock Function) 정의
+const mockGetRoom = getRoom as jest.Mock;
 const mockGetUserFromRoom = getUserFromRoom as jest.Mock;
 const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.Mock;
+const mockRemoveCard = removeCard as jest.Mock;
 
 describe('cardDesertEagleEffect', () => {
 	const ROOM_ID = 1;
 	const USER_ID = 'user-1';
 	let mockUser: User;
+	let mockRoom: Room;
 
 	beforeEach(() => {
-		// 각 테스트가 독립적으로 실행되도록 모든 모의 함수를 초기화합니다.
+		// 각 테스트 실행 전 모의 객체 초기화
 		jest.clearAllMocks();
 
-		// 테스트에 사용할 기본 유저 객체를 설정합니다.
+		// 테스트에 사용할 기본 객체 설정
 		mockUser = new User(USER_ID, 'test-user');
 		mockUser.character = {
 			characterType: CharacterType.PINK_SLIME,
@@ -47,18 +58,21 @@ describe('cardDesertEagleEffect', () => {
 			},
 			bbangCount: 0,
 		} as CharacterData;
+		mockRoom = new Room(ROOM_ID, mockUser.id, 'test-room', 2, RoomStateType.INGAME, [mockUser]);
 
-		// 모의 함수의 기본 동작을 동기적으로 설정합니다.
+		// 모의 함수의 기본 동작 설정
 		mockGetUserFromRoom.mockReturnValue(mockUser);
+		mockGetRoom.mockReturnValue(mockRoom);
 		mockUpdateCharacterFromRoom.mockImplementation(() => {}); // void 함수
 	});
 
 	it('성공적으로 데저트 이글을 장착하고 true를 반환해야 합니다', () => {
-		// Act: 테스트할 함수를 실행합니다.
+		// 실행: 테스트할 함수를 실행합니다.
 		const result = cardDesertEagleEffect(ROOM_ID, USER_ID);
 
-		// Assert: 결과를 검증합니다.
+		// 검증: 결과를 검증합니다.
 		expect(result).toBe(true);
+		expect(mockRemoveCard).toHaveBeenCalledTimes(1);
 		expect(mockGetUserFromRoom).toHaveBeenCalledWith(ROOM_ID, USER_ID);
 		expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(
 			ROOM_ID,
@@ -70,14 +84,15 @@ describe('cardDesertEagleEffect', () => {
 	});
 
 	it('기존에 다른 무기를 가지고 있었다면, 덮어써야 합니다', () => {
-		// Arrange: 유저가 이미 다른 무기를 가지고 있는 상황을 설정합니다.
+		// 준비: 유저가 이미 다른 무기를 가지고 있는 상황을 설정합니다.
 		mockUser.character!.weapon = CardType.HAND_GUN;
 
-		// Act
+		// 실행
 		const result = cardDesertEagleEffect(ROOM_ID, USER_ID);
 
-		// Assert
+		// 검증
 		expect(result).toBe(true);
+		expect(mockRemoveCard).toHaveBeenCalledTimes(1);
 		expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(
 			ROOM_ID,
 			USER_ID,
@@ -88,48 +103,45 @@ describe('cardDesertEagleEffect', () => {
 	});
 
 	it('유저를 찾을 수 없으면 false를 반환해야 합니다', () => {
-		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-		const notFoundError = new Error('User not found');
-		// Arrange: 유저를 찾을 수 없는 상황 (에러 발생)을 설정합니다.
-		mockGetUserFromRoom.mockImplementation(() => {
-			throw notFoundError;
-		});
+		// 준비: 유저를 찾을 수 없는 상황 (null 반환)을 설정합니다.
+		mockGetUserFromRoom.mockReturnValue(null);
 
-		// Act
+		// 실행
 		const result = cardDesertEagleEffect(ROOM_ID, USER_ID);
 
-		// Assert
+		// 검증
 		expect(result).toBe(false);
+		expect(mockRemoveCard).not.toHaveBeenCalled();
 		expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled(); // 캐릭터 업데이트 함수가 호출되지 않았는지 확인
-		expect(consoleErrorSpy).toHaveBeenCalledWith('[데저트 이글] 업데이트 실패:', notFoundError);
-		consoleErrorSpy.mockRestore();
 	});
 
 	it('유저의 캐릭터 정보가 없으면 false를 반환해야 합니다', () => {
-		// Arrange: 캐릭터 정보가 없는 상황을 설정합니다.
+		// 준비: 캐릭터 정보가 없는 상황을 설정합니다.
 		mockUser.character = undefined;
 
-		// Act
+		// 실행
 		const result = cardDesertEagleEffect(ROOM_ID, USER_ID);
 
-		// Assert
+		// 검증
 		expect(result).toBe(false);
+		expect(mockRemoveCard).not.toHaveBeenCalled();
 		expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
 	});
 
 	it('캐릭터 정보 업데이트에 실패하면 false를 반환해야 합니다', () => {
-		// Arrange: DB 업데이트 실패 상황 (에러 발생)을 설정합니다.
+		// 준비: DB 업데이트 실패 상황 (에러 발생)을 설정합니다.
 		const dbError = new Error('DB update failed');
 		mockUpdateCharacterFromRoom.mockImplementation(() => {
 			throw dbError;
 		});
 		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); // 테스트 중 콘솔 에러 출력을 막습니다.
 
-		// Act
+		// 실행
 		const result = cardDesertEagleEffect(ROOM_ID, USER_ID);
 
-		// Assert
+		// 검증
 		expect(result).toBe(false);
+		expect(mockRemoveCard).toHaveBeenCalledTimes(1); // 업데이트 실패 전 카드 제거는 호출되어야 함
 		expect(consoleErrorSpy).toHaveBeenCalledWith('[데저트 이글] 업데이트 실패:', dbError); // 에러 로그가 정상적으로 출력되었는지 확인
 		consoleErrorSpy.mockRestore();
 	});

--- a/game.server/src/card/test/card.satellite_target.effect.test.ts
+++ b/game.server/src/card/test/card.satellite_target.effect.test.ts
@@ -5,6 +5,7 @@ import cardSatelliteTargetEffect from '../card.satellite_target.effect';
 import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../../utils/room.utils';
 import { playAnimationHandler } from '../../handlers/play.animation.handler';
 import { checkAndEndGameIfNeeded } from '../../utils/game.end.util';
+import { removeCard } from '../../managers/card.manager';
 
 // Mocks
 jest.mock('../../utils/room.utils', () => ({
@@ -21,6 +22,10 @@ jest.mock('../../utils/game.end.util', () => ({
 	checkAndEndGameIfNeeded: jest.fn(),
 }));
 
+jest.mock('../../managers/card.manager', () => ({
+	removeCard: jest.fn(),
+}));
+
 const mockGetRoom = getRoom as jest.MockedFunction<typeof getRoom>;
 const mockGetUserFromRoom = getUserFromRoom as jest.MockedFunction<typeof getUserFromRoom>;
 const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.MockedFunction<
@@ -32,6 +37,7 @@ const mockPlayAnimationHandler = playAnimationHandler as jest.MockedFunction<
 const mockCheckAndEndGameIfNeeded = checkAndEndGameIfNeeded as jest.MockedFunction<
 	typeof checkAndEndGameIfNeeded
 >;
+const mockRemoveCard = removeCard as jest.Mock;
 
 describe('위성 타겟 효과 테스트', () => {
 	const mockRoomId = 1;
@@ -84,6 +90,7 @@ describe('위성 타겟 효과 테스트', () => {
 			const result = cardSatelliteTargetEffect(mockRoomId, mockUserId, mockTargetUserId);
 
 			expect(result).toBe(true);
+			expect(mockRemoveCard).toHaveBeenCalledTimes(1)
 			expect(mockTarget.character.debuffs).toContain(CardType.SATELLITE_TARGET);
 			expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(
 				mockRoomId,
@@ -116,6 +123,7 @@ describe('위성 타겟 효과 테스트', () => {
 			const result = cardSatelliteTargetEffect(mockRoomId, mockUserId, mockTargetUserId);
 
 			expect(result).toBe(false);
+			expect(mockRemoveCard).toHaveBeenCalledTimes(0)
 			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
 			expect(consoleErrorSpy).toHaveBeenCalledWith(`[SatelliteTarget] 위성 타겟 적용 중 오류 발생: ${notFoundError}`);
 			consoleErrorSpy.mockRestore();
@@ -128,6 +136,7 @@ describe('위성 타겟 효과 테스트', () => {
 			const result = cardSatelliteTargetEffect(mockRoomId, mockUserId, mockTargetUserId);
 
 			expect(result).toBe(false);
+			expect(mockRemoveCard).toHaveBeenCalledTimes(0)
 			expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
 		});
 
@@ -143,6 +152,7 @@ describe('위성 타겟 효과 테스트', () => {
 			const result = cardSatelliteTargetEffect(mockRoomId, mockUserId, mockTargetUserId);
 
 			expect(result).toBe(false);
+			expect(mockRemoveCard).toHaveBeenCalledTimes(1)
 			expect(consoleErrorSpy).toHaveBeenCalledWith(`[SatelliteTarget] 위성 타겟 적용 중 오류 발생: ${updateError}`);
 			consoleErrorSpy.mockRestore();
 		});

--- a/game.server/src/card/test/card.vaccine.effect.test.ts
+++ b/game.server/src/card/test/card.vaccine.effect.test.ts
@@ -1,93 +1,110 @@
+import { removeCard } from '../../managers/card.manager';
 import cardVaccineEffect from '../card.vaccine.effect';
-import { getUserFromRoom, updateCharacterFromRoom } from '../../utils/room.utils';
+import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../../utils/room.utils';
 import getMaxHp from '../../utils/character.util';
 import { User } from '../../models/user.model';
 import { Character } from '../../models/character.model';
-import { CharacterType, RoleType } from '../../generated/common/enums';
+import { CharacterType, RoleType, RoomStateType } from '../../generated/common/enums';
+import { Room } from '../../models/room.model';
 
-// Mocks
+// 의존성 모의(Mock) 설정
 jest.mock('../../utils/room.utils', () => ({
+	getRoom: jest.fn(),
 	getUserFromRoom: jest.fn(),
 	updateCharacterFromRoom: jest.fn(),
 }));
 
 jest.mock('../../utils/character.util', () => ({
-	__esModule: true, // for default export
+	__esModule: true, // default export
 	default: jest.fn(),
 }));
 
+jest.mock('../../managers/card.manager', () => ({
+	removeCard: jest.fn(),
+}));
+
+// 모의 함수(Mock Function) 정의
+const mockGetRoom = getRoom as jest.Mock;
 const mockGetUserFromRoom = getUserFromRoom as jest.Mock;
 const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.Mock;
 const mockGetMaxHp = getMaxHp as jest.Mock;
+const mockRemoveCard = removeCard as jest.Mock;
 
 describe('cardVaccineEffect', () => {
 	const roomId = 1;
 	const userId = 'user1';
 
 	let user: User;
+	let room: Room;
 
 	beforeEach(() => {
-		// Reset mocks before each test
+		// 각 테스트 실행 전 모의 객체 초기화
 		jest.clearAllMocks();
 
-		// Default mock implementations
+		// 모의 객체의 기본 구현 설정
 		user = new User(userId, 'test-socket');
+		room = new Room(roomId, user.id, 'test-room', 2, RoomStateType.INGAME, [user]);
 		mockGetUserFromRoom.mockReturnValue(user);
+		mockGetRoom.mockReturnValue(room);
 		mockUpdateCharacterFromRoom.mockImplementation(() => {});
 		mockGetMaxHp.mockImplementation((charType: CharacterType) => {
 			if (charType === CharacterType.DINOSAUR) return 3;
-			return 4; // Default for RED, etc.
+			return 4; // RED 등 다른 캐릭터의 기본 최대 체력
 		});
 	});
 
 	test('체력이 최대치보다 낮을 때 true를 반환하고 체력이 1 회복되어야 합니다.', () => {
-		// GIVEN: Character with HP 3/4
+		// 준비 (Given): 캐릭터의 현재 체력이 최대 체력보다 낮음 (3/4)
 		user.character = new Character(CharacterType.RED, RoleType.NONE_ROLE, 3, 0, [], [], [], 1, 0);
 
-		// WHEN
+		// 실행 (When): 백신 카드 효과를 적용
 		const result = cardVaccineEffect(roomId, userId);
 
-		// THEN
+		// 검증 (Then): true를 반환하고, 카드가 제거되며, 체력이 1 증가해야 함
 		expect(result).toBe(true);
+		expect(mockRemoveCard).toHaveBeenCalledTimes(1);
 		expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(1);
 		expect(user.character.hp).toBe(4);
 	});
 
 	test('체력이 최대치일 때 false를 반환하고 회복되지 않아야 합니다.', () => {
-		// GIVEN: Character with HP 4/4
+		// 준비 (Given): 캐릭터의 현재 체력이 최대 체력과 같음 (4/4)
 		user.character = new Character(CharacterType.RED, RoleType.NONE_ROLE, 4, 0, [], [], [], 1, 0);
 
-		// WHEN
+		// 실행 (When): 백신 카드 효과를 적용
 		const result = cardVaccineEffect(roomId, userId);
 
-		// THEN
+		// 검증 (Then): false를 반환하고, 카드가 제거되지 않으며, 체력도 변하지 않아야 함
 		expect(result).toBe(false);
+		expect(mockRemoveCard).not.toHaveBeenCalled();
 		expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
 		expect(user.character.hp).toBe(4);
 	});
 
 	test('최대 체력이 3인 캐릭터(공룡)가 체력을 회복해야 합니다.', () => {
-		// GIVEN: Dinosaur with HP 2/3
+		// 준비 (Given): 공룡 캐릭터의 현재 체력이 최대 체력보다 낮음 (2/3)
 		user.character = new Character(CharacterType.DINOSAUR, RoleType.NONE_ROLE, 2, 0, [], [], [], 1, 0);
 
-		// WHEN
+		// 실행 (When): 백신 카드 효과를 적용
 		const result = cardVaccineEffect(roomId, userId);
 
-		// THEN
+		// 검증 (Then): true를 반환하고, 카드가 제거되며, 체력이 1 증가해야 함
 		expect(result).toBe(true);
+		expect(mockRemoveCard).toHaveBeenCalledTimes(1);
 		expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(1);
 		expect(user.character.hp).toBe(3);
 	});
 
 	test('최대 체력이 3인 캐릭터(공룡)가 최대 체력일 때 회복하지 않아야 합니다.', () => {
-		// GIVEN: Dinosaur with HP 3/3
+		// 준비 (Given): 공룡 캐릭터의 현재 체력이 최대 체력과 같음 (3/3)
 		user.character = new Character(CharacterType.DINOSAUR, RoleType.NONE_ROLE, 3, 0, [], [], [], 1, 0);
 
-		// WHEN
+		// 실행 (When): 백신 카드 효과를 적용
 		const result = cardVaccineEffect(roomId, userId);
 
-		// THEN
+		// 검증 (Then): false를 반환하고, 카드가 제거되지 않으며, 체력도 변하지 않아야 함
 		expect(result).toBe(false);
+		expect(mockRemoveCard).not.toHaveBeenCalled();
 		expect(mockUpdateCharacterFromRoom).not.toHaveBeenCalled();
 		expect(user.character.hp).toBe(3);
 	});
@@ -95,30 +112,32 @@ describe('cardVaccineEffect', () => {
 	test('유저를 찾을 수 없을 때 false를 반환해야 합니다.', () => {
 		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 		const notFoundError = new Error('User not found');
-		// GIVEN
+		// 준비 (Given): getUserFromRoom 함수가 에러를 발생시키도록 설정
 		mockGetUserFromRoom.mockImplementation(() => {
 			throw notFoundError;
 		});
 
-		// WHEN
+		// 실행 (When): 백신 카드 효과를 적용
 		const result = cardVaccineEffect(roomId, userId);
 
-		// THEN
+		// 검증 (Then): false를 반환하고, 에러 로그가 출력되어야 함
 		expect(result).toBe(false);
+		expect(mockRemoveCard).not.toHaveBeenCalled();
 		expect(consoleErrorSpy).toHaveBeenCalledWith('[백신] 처리 중 오류 발생:', notFoundError);
 		consoleErrorSpy.mockRestore();
 	});
 
 	test('캐릭터가 없을 때 false를 반환해야 합니다.', () => {
 		const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-		// GIVEN
+		// 준비 (Given): 유저의 캐릭터 정보가 없는 상태로 설정
 		user.character = undefined;
 
-		// WHEN
+		// 실행 (When): 백신 카드 효과를 적용
 		const result = cardVaccineEffect(roomId, userId);
 
-		// THEN
+		// 검증 (Then): false를 반환하고, 경고 로그가 출력되어야 함
 		expect(result).toBe(false);
+		expect(mockRemoveCard).not.toHaveBeenCalled();
 		expect(consoleWarnSpy).toHaveBeenCalledWith(`[백신] 유저의 캐릭터 정보가 없습니다: ${userId}`);
 		consoleWarnSpy.mockRestore();
 	});
@@ -126,18 +145,19 @@ describe('cardVaccineEffect', () => {
 	test('DB 업데이트 실패 시 false를 반환해야 합니다.', () => {
 		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 		const updateError = new Error('Update failed');
-		// GIVEN
+		// 준비 (Given): 체력은 회복 가능하지만, DB 업데이트 시 에러가 발생하도록 설정
 		user.character = new Character(CharacterType.RED, RoleType.NONE_ROLE, 3, 0, [], [], [], 1, 0);
 		mockUpdateCharacterFromRoom.mockImplementation(() => {
 			throw updateError;
 		});
 
-		// WHEN
+		// 실행 (When): 백신 카드 효과를 적용
 		const result = cardVaccineEffect(roomId, userId);
 
-		// THEN
+		// 검증 (Then): false를 반환하지만, 카드는 제거되어야 함
 		expect(result).toBe(false);
-		// The in-memory object is still mutated, but the function returns false
+		expect(mockRemoveCard).toHaveBeenCalledTimes(1);
+		// 메모리 상의 객체는 변경되지만, 함수는 false를 반환하고 에러 로그를 남김
 		expect(user.character.hp).toBe(4);
 		expect(consoleErrorSpy).toHaveBeenCalledWith('[백신] 처리 중 오류 발생:', updateError);
 		consoleErrorSpy.mockRestore();


### PR DESCRIPTION
##내용
흡수, 위성타겟, 자동쉴드, 데저트이글, 백신 카드 및 테스트 코드에 다 적용 완료했습니다.

카드 사용 조건 충족시 실행하도록 로직 작성

