### PR TITLE
Fix/cards/kimdandy

### DIFF
--- a/game.server/src/card/card.auto_rifle.effect.ts
+++ b/game.server/src/card/card.auto_rifle.effect.ts
@@ -1,39 +1,37 @@
 // cardType = 16
 
 import { CardType } from '../generated/common/enums';
-import { getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
-import { repeatDeck } from '../managers/card.manager';
+import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
+import { removeCard, repeatDeck } from '../managers/card.manager';
 
 const cardAutoRifleEffect = (roomId: number, userId: string): boolean => {
 	// 정보값 가져오기
 	const user = getUserFromRoom(roomId, userId);
+	const room = getRoom(roomId);
 	// 유효성 검증
-	if (!user || !user.character || !user.character.stateInfo) return false;
-
-	// 여러 검증을 했다면 카드 제거 및 검증 로직 실행
-	const haveCard = user.character.handCards.find(c => c.type === CardType.AUTO_RIFLE);
-	if (!haveCard) {
-		console.warn('[CardType:AUTO_RIFLE] 해당 카드를 소유하고 있지 않습니다')
+	if (!user || !user.character || !user.character.stateInfo) {
+		console.error('[AUTO_RIFLE]사용자 정보가 존재하지 않습니다');
 		return false;
 	}
-	haveCard.count -= 1;
-	if ( haveCard.count <=0 ){
-		const lastCardIndex = user.character.handCards.findIndex(c => c.type === CardType.AUTO_RIFLE);
-		user.character.handCards.splice(lastCardIndex, 1);
+	if (!room) {
+		console.error('[AUTO_RIFLE]방이 존재하지 않습니다.');
+		return false;
 	}
-	repeatDeck(roomId, [CardType.AUTO_RIFLE]);
 
+	// 카드 제거
+	removeCard(user, room, CardType.AUTO_RIFLE);
 	
-	user.character.weapon = CardType.AUTO_RIFLE; // 16;AUTO_RIFLE 장착
+	// 16;AUTO_RIFLE 장착
+	user.character.weapon = CardType.AUTO_RIFLE; 
 	
 
 	// 수정 정보 갱신
 	try {
 		updateCharacterFromRoom(roomId, userId, user.character);
 		return true;
-		//console.log('로그 저장에 성공하였습니다');
+		//console.log('[AUTO_RIFLE]로그 저장에 성공하였습니다');
 	} catch (error) {
-		console.error(`로그 저장에 실패하였습니다:[${error}]`);
+		console.error(`[AUTO_RIFLE]로그 저장에 실패하였습니다:[${error}]`);
 		return false;
 	}
 };

--- a/game.server/src/card/card.bbang.effect.ts
+++ b/game.server/src/card/card.bbang.effect.ts
@@ -2,7 +2,7 @@
 import { getUserFromRoom, updateCharacterFromRoom, getRoom } from '../utils/room.utils';
 import { CardType, CharacterStateType } from '../generated/common/enums';
 import { CheckGuerrillaService } from '../services/guerrilla.check.service';
-import { repeatDeck } from '../managers/card.manager';
+import { removeCard } from '../managers/card.manager';
 
 const cardBbangEffect = (roomId: number, userId: string, targetUserId: string): boolean => {
 	// 정보값 가져오기
@@ -11,39 +11,27 @@ const cardBbangEffect = (roomId: number, userId: string, targetUserId: string): 
 	const room = getRoom(roomId);
 
 	// 유효성 검증
-
 	if (!room) {
-		console.log('방이 존재하지 않습니다.');
+		console.error('[BBANG]방이 존재하지 않습니다.');
 		return false;
 	}
 	if (!user || !user.character || !user.character.stateInfo) {
-		console.log('사용자 정보가 존재하지 않습니다');
+		console.error('[BBANG]사용자 정보가 존재하지 않습니다');
 		return false;
 	}
 	if (!target || !target.character || !target.character.stateInfo) {
-		console.log('타깃 유저의 정보가 존재하지 않습니다 ');
+		console.error('[BBANG]타깃 유저의 정보가 존재하지 않습니다 ');
 		return false;
 	}
 
 	// 타겟 유저가 사망 상태라면 불발 처리
 	if (target.character.hp <= 0) {
-		console.log('타깃 유저의 체력이 이미 0 입니다.');
+		console.error('[BBANG]타깃 유저의 체력이 이미 0 입니다.');
 		return false;
 	}
-	//if (!user || !target || !user.character || !target.character) return false;
 
-	// 여러 검증을 했다면 카드 제거 및 검증 로직 실행
-	const haveCard = user.character.handCards.find(c => c.type === CardType.BBANG);
-	if (!haveCard) {
-		console.warn('[CardType:BBANG] 해당 카드를 소유하고 있지 않습니다')
-		return false;
-	}
-	haveCard.count -= 1;
-	if ( haveCard.count <=0 ){
-		const lastCardIndex = user.character.handCards.findIndex(c => c.type === CardType.BBANG);
-		user.character.handCards.splice(lastCardIndex, 1);
-	}
-	repeatDeck(roomId, [CardType.BBANG]);
+	// 카드 제거
+	removeCard(user, room, CardType.BBANG);
 	
 	
 	if (user.character.stateInfo.state === CharacterStateType.NONE_CHARACTER_STATE) {
@@ -85,9 +73,9 @@ const cardBbangEffect = (roomId: number, userId: string, targetUserId: string): 
 		updateCharacterFromRoom(roomId, userId, user.character);
 		updateCharacterFromRoom(roomId, targetUserId, target.character);
 		return true;
-		//console.log('로그 저장에 성공하였습니다');
+		//console.log('[BBANG]로그 저장에 성공하였습니다');
 	} catch (error) {
-		console.error(`로그 저장에 실패하였습니다:[${error}]`);
+		console.error(`[BBANG]로그 저장에 실패하였습니다:[${error}]`);
 		return false;
 	}
 };

--- a/game.server/src/card/card.containment_unit.effect.ts
+++ b/game.server/src/card/card.containment_unit.effect.ts
@@ -1,7 +1,7 @@
 // cardType = 21
 import { getUserFromRoom, updateCharacterFromRoom, getRoom } from '../utils/room.utils';
 import { CardType, CharacterStateType } from '../generated/common/enums';
-import { repeatDeck } from '../managers/card.manager';
+import { removeCard } from '../managers/card.manager';
 
 // 디버프 적용 처리 로직
 const cardContainmentUnitEffect = (
@@ -11,27 +11,29 @@ const cardContainmentUnitEffect = (
 ): boolean => {
 	const user = getUserFromRoom(roomId, userId);
 	const target = getUserFromRoom(roomId, targetUserId);
-	// 유효성 검증s
-	if (!user || !user.character || !target || !target.character) return false;
+	const room = getRoom(roomId);
+	// 유효성 검증
+	if (!user || !user.character || !user.character.stateInfo) {
+		console.error('[CONTAINMENT_UNIT]사용자 정보가 존재하지 않습니다');
+		return false;
+	}
+	if (!target || !target.character || !target.character.stateInfo) {
+		console.error('[CONTAINMENT_UNIT]타깃 유저의 정보가 존재하지 않습니다 ');
+		return false;
+	}
+	if (!room) {
+		console.error('[CONTAINMENT_UNIT]방이 존재하지 않습니다.');
+		return false;
+	}
 
 	// 이미 해당 디버프 상태일 경우 ; 중복 검증
 	if (target.character.debuffs.includes(CardType.CONTAINMENT_UNIT)) {
-		console.log(`이미 ${target.nickname} 유저는 감금 장치에 맞았습니다. `);
+		console.error(`[CONTAINMENT_UNIT]이미 ${target.nickname} 유저는 감금 장치에 맞았습니다. `);
 		return false;
 	}
 
-	// 여러 검증을 했다면 카드 제거 및 검증 로직 실행
-	const haveCard = user.character.handCards.find(c => c.type === CardType.CONTAINMENT_UNIT);
-	if (!haveCard) {
-		console.warn('[CardType:CONTAINMENT_UNIT] 해당 카드를 소유하고 있지 않습니다')
-		return false;
-	}
-	haveCard.count -= 1;
-	if ( haveCard.count <=0 ){
-		const lastCardIndex = user.character.handCards.findIndex(c => c.type === CardType.CONTAINMENT_UNIT);
-		user.character.handCards.splice(lastCardIndex, 1);
-	}
-	repeatDeck(roomId, [CardType.CONTAINMENT_UNIT])
+	// 카드 제거
+	removeCard(user, room, CardType.CONTAINMENT_UNIT);
 
 	target.character.debuffs.push(CardType.CONTAINMENT_UNIT);
 	//console.log(`유저 ${targetUserId}가 감금장치 카드에 맞았습니다.\n다음 차례부터 감금장치에 영향을 받습니다.`);
@@ -39,10 +41,10 @@ const cardContainmentUnitEffect = (
 	// 수정 정보 갱신
 	try {
 		updateCharacterFromRoom(roomId, targetUserId, target.character);
-		//console.log('로그 저장에 성공하였습니다');
+		//console.log('[CONTAINMENT_UNIT]로그 저장에 성공하였습니다');
 		return true;
 	} catch (error) {
-		console.error(`로그 저장에 실패하였습니다:[${error}]`);
+		console.error(`[CONTAINMENT_UNIT]로그 저장에 실패하였습니다:[${error}]`);
 		return false;
 	}
 };
@@ -51,7 +53,7 @@ const cardContainmentUnitEffect = (
 export const checkContainmentUnitTarget = async (roomId: number) => {
 	const room = getRoom(roomId);
 	if (!room || !room.users) {
-		console.warn(`[ContainmentUnitTarget] 방을 찾을 수 없습니다: roomId=${roomId}`);
+		console.error(`[debuffCONTAINMENT_UNIT] 방을 찾을 수 없습니다: roomId=${roomId}`);
 		return room;
 	}
 
@@ -60,7 +62,7 @@ export const checkContainmentUnitTarget = async (roomId: number) => {
 		(user) => user.character && user.character.debuffs.includes(CardType.CONTAINMENT_UNIT),
 	);
 
-	// console.log(`[ContainmentUnitTarget] 디버프를 가진 유저 수: ${usersWithDebuff.length}`);
+	// console.log(`[debuffCONTAINMENT_UNIT] 디버프를 가진 유저 수: ${usersWithDebuff.length}`);
 
 	for (const user of usersWithDebuff) {
 		debuffContainmentUnitEffect(roomId, user.id);
@@ -76,33 +78,33 @@ export const debuffContainmentUnitEffect = (roomId: number, userId: string) => {
 	const user = getUserFromRoom(roomId, userId);
 	if (!user || !user.character) return;
 
-	console.log(`[debuffContainmentUnit] (${user.nickname}) : 유저정보식별 성공`);
+	//console.log(`[debuffCONTAINMENT_UNIT] (${user.nickname}) : 유저정보식별 성공`);
 
 	// 탈출 확률
 	const escapeProb = 25; 
 	// 실제확률 25; // 테스트용 99; 
 
 	if (user.character.debuffs.includes(CardType.CONTAINMENT_UNIT)) {
-		console.log(`[debuffContainmentUnit] (${user.nickname}) : 디버프 카드 등록 상태 인지 성공`);
+		//console.log(`[debuffCONTAINMENT_UNIT] (${user.nickname}) : 디버프 카드 등록 상태 인지 성공`);
 
 		switch (user.character.stateInfo!.state) {
 			case CharacterStateType.NONE_CHARACTER_STATE: // 첫날은 탈출 불가
-				console.log(
-					`[debuffContainmentUnit] (${user.nickname}) : 현재 상태 : ${CharacterStateType[user.character.stateInfo!.state]}`,
-				);
+				// console.log(
+				// 	`[debuffCONTAINMENT_UNIT] (${user.nickname}) : 현재 상태 : ${CharacterStateType[user.character.stateInfo!.state]}`,
+				// );
 
 				user.character.stateInfo!.state = CharacterStateType.CONTAINED;
 				//user.character.stateInfo!.nextState = CharacterStateType.CONTAINED;
 
-				console.log(
-					`[debuffContainmentUnit] (${user.nickname}) : 디버프 감염 완료 : ${CharacterStateType[user.character.stateInfo!.state]}`,
-				);
+				// console.log(
+				// 	`[debuffCONTAINMENT_UNIT] (${user.nickname}) : 디버프 감염 완료 : ${CharacterStateType[user.character.stateInfo!.state]}`,
+				// );
 
 				try {
 					updateCharacterFromRoom(roomId, userId, user.character);
-					console.log(`[debuffContainmentUnit] (${user.nickname}) :  로그 저장에 성공하였습니다`);
+					//console.log(`[debuffCONTAINMENT_UNIT] (${user.nickname}) :  로그 저장에 성공하였습니다`);
 				} catch (error) {
-					console.error(`로그 저장에 실패하였습니다:[${error}]`);
+					console.error(`[debuffCONTAINMENT_UNIT]로그 저장에 실패하였습니다:[${error}]`);
 				}
 
 				break;
@@ -110,7 +112,7 @@ export const debuffContainmentUnitEffect = (roomId: number, userId: string) => {
 				const yourProb = Math.random() * 100;
 
 				console.log(
-					`[debuffContainmentUnit] (${user.nickname}) : 탈출에 성공하면 디버프 상태 해제`,
+					`[debuffCONTAINMENT_UNIT] (${user.nickname}) : 탈출에 성공하면 디버프 상태 해제`,
 				);
 
 				if (yourProb < escapeProb) {
@@ -121,13 +123,13 @@ export const debuffContainmentUnitEffect = (roomId: number, userId: string) => {
 						(c) => c === CardType.CONTAINMENT_UNIT,
 					);
 					user.character.debuffs.splice(yourDebuffIndex, 1);
-					console.log(`[debuffContainmentUnit]${user.nickname} 유저가 감금 상태에서 탈출에 성공했습니다`);
+					console.log(`[debuffCONTAINMENT_UNIT]${user.nickname} 유저가 감금 상태에서 탈출에 성공했습니다`);
 
 					try {
 						updateCharacterFromRoom(roomId, userId, user.character);
-						//console.log(`[debuffContainmentUnit] (${user.nickname}) :  로그 저장에 성공하였습니다`);
+						//console.log(`[debuffCONTAINMENT_UNIT] (${user.nickname}) :  로그 저장에 성공하였습니다`);
 					} catch (error) {
-						console.error(`[debuffContainmentUnit]로그 저장에 실패하였습니다:[${error}]`);
+						console.error(`[debuffCONTAINMENT_UNIT]로그 저장에 실패하였습니다:[${error}]`);
 					}
 				}
 				break;
@@ -135,9 +137,9 @@ export const debuffContainmentUnitEffect = (roomId: number, userId: string) => {
 				break;
 		}
 
-		console.log(
-			`[debuffContainmentUnit] (${user.nickname}) : 로직 종료 : ${CharacterStateType[user.character.stateInfo!.state]}`,
-		);
+		// console.log(
+		// 	`[debuffCONTAINMENT_UNIT] (${user.nickname}) : 로직 종료 : ${CharacterStateType[user.character.stateInfo!.state]}`,
+		// );
 	}
 
 	return user;

--- a/game.server/src/card/card.laser_pointer.effect.ts
+++ b/game.server/src/card/card.laser_pointer.effect.ts
@@ -1,31 +1,28 @@
 // cardType = 17
-import { getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
+import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../utils/room.utils';
 import { CardType } from '../generated/common/enums';
-import { repeatDeck } from '../managers/card.manager';
+import { removeCard } from '../managers/card.manager';
 
 const cardLaserPointerEffect = (roomId: number, userId: string) : boolean => {
 	const user = getUserFromRoom(roomId, userId);
+	const room = getRoom(roomId);
 	// 유효성 검증
-	if (!user || !user.character) return false;
-
-	// 여러 검증을 했다면 카드 제거 및 검증 로직 실행
-	const haveCard = user.character.handCards.find(c => c.type === CardType.LASER_POINTER);
-	if (!haveCard) {
-		console.warn('[CardType:LASER_POINTER] 해당 카드를 소유하고 있지 않습니다')
+	if (!user || !user.character) {
+		console.log('[LASER_POINTER]사용자 정보가 존재하지 않습니다');
 		return false;
 	}
-	haveCard.count -= 1;
-	if ( haveCard.count <=0 ){
-		const lastCardIndex = user.character.handCards.findIndex(c => c.type === CardType.LASER_POINTER);
-		user.character.handCards.splice(lastCardIndex, 1);
+	if (!room) {
+		console.log('[LASER_POINTER]방이 존재하지 않습니다.');
+		return false;
 	}
 
-	// 중복 착용 중일 경우
 	if (!user.character.equips.includes(CardType.LASER_POINTER)) {
 		user.character.equips.push(CardType.LASER_POINTER);
-		// 처리 후 덱으로 회수
-		repeatDeck(roomId, [CardType.LASER_POINTER]);
+		
+		// 카드 제거
+		removeCard(user, room, CardType.LASER_POINTER);
 	} else {
+		// 중복 착용 중일 경우
 		return false;
 	}
 
@@ -33,9 +30,9 @@ const cardLaserPointerEffect = (roomId: number, userId: string) : boolean => {
 	try{
 		updateCharacterFromRoom(roomId, userId, user.character);
 		return true;
-		//console.log('로그 저장에 성공하였습니다');
+		//console.log('[LASER_POINTER]로그 저장에 성공하였습니다');
 	} catch (error) {
-		console.error(`로그 저장에 실패하였습니다:[${error}]`);
+		console.error(`[LASER_POINTER]로그 저장에 실패하였습니다:[${error}]`);
 		return false;
 	}
 };

--- a/game.server/src/card/test/card.bbang.effect.test.ts
+++ b/game.server/src/card/test/card.bbang.effect.test.ts
@@ -3,7 +3,7 @@ import { Room } from '../../models/room.model';
 import { User } from '../../models/user.model';
 import { CheckGuerrillaService } from '../../services/guerrilla.check.service';
 import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../../utils/room.utils';
-import { repeatDeck } from '../../managers/card.manager';
+import { removeCard } from '../../managers/card.manager';
 import cardBbangEffect from '../card.bbang.effect';
 
 // Mock dependencies
@@ -16,7 +16,7 @@ const mockGetRoom = getRoom as jest.Mock;
 const mockGetUserFromRoom = getUserFromRoom as jest.Mock;
 const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.Mock;
 const mockCheckGuerrillaService = CheckGuerrillaService as jest.Mock;
-const mockRepeatDeck = repeatDeck as jest.Mock;
+const mockRemoveCard = removeCard as jest.Mock;
 
 describe('cardBbangEffect', () => {
   let mockRoom: Room;
@@ -25,9 +25,7 @@ describe('cardBbangEffect', () => {
   const roomId = 1;
   const userId = 'user-1';
   const targetId = 'target-1';
-  let consoleLogSpy: jest.SpyInstance;
   let consoleErrorSpy: jest.SpyInstance;
-  let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -35,9 +33,7 @@ describe('cardBbangEffect', () => {
     const now = Date.now();
     jest.spyOn(Date, 'now').mockReturnValue(now);
 
-    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     user = new User(userId, 'User');
     user.character = {
@@ -59,40 +55,30 @@ describe('cardBbangEffect', () => {
   });
 
   afterEach(() => {
-    consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
-    consoleWarnSpy.mockRestore();
   });
 
   // --- Validation Tests ---
 
-  it('방, 유저, 타겟 정보가 없으면 false를 반환해야 한다', () => {
+  it('방이 없으면 false 반환', () => {
     mockGetRoom.mockReturnValueOnce(null);
     expect(cardBbangEffect(roomId, userId, targetId)).toBe(false);
+  });
 
+  it('유저 정보가 없으면 false 반환', () => {
     mockGetUserFromRoom.mockImplementationOnce(() => null);
     expect(cardBbangEffect(roomId, userId, targetId)).toBe(false);
-
-    user.character = undefined;
-    expect(cardBbangEffect(roomId, userId, targetId)).toBe(false);
   });
 
-  it('타겟의 HP가 0 이하면 false를 반환해야 한다', () => {
+  it('타겟 HP가 0 이하면 false 반환', () => {
     target.character!.hp = 0;
-    expect(cardBbangEffect(roomId, userId, targetId)).toBe(false);
-    expect(consoleLogSpy).toHaveBeenCalledWith('타깃 유저의 체력이 이미 0 입니다.');
-  });
-
-  it('카드를 소유하지 않으면 false를 반환해야 한다', () => {
-    user.character!.handCards = [];
-    const result = cardBbangEffect(roomId, userId, targetId);
-    expect(result).toBe(false);
-    expect(consoleWarnSpy).toHaveBeenCalledWith('[CardType:BBANG] 해당 카드를 소유하고 있지 않습니다');
+	const ishp0 = cardBbangEffect(roomId, userId, targetId);
+    expect(ishp0).toBe(false);
   });
 
   // --- State-based Logic Tests ---
 
-  it('일반 상태에서 빵야를 사용하면, BBANG 상태로 변경해야 한다', () => {
+  it('일반 상태에서 빵야를 사용하면 BBANG 상태로 변경', () => {
     const now = Date.now();
     const expectedNextStateAt = `${now + 10000}`;
 
@@ -100,31 +86,26 @@ describe('cardBbangEffect', () => {
 
     expect(result).toBe(true);
     expect(user.character!.stateInfo!.state).toBe(CharacterStateType.BBANG_SHOOTER);
-    expect(user.character!.stateInfo!.stateTargetUserId).toBe(targetId);
-    expect(user.character!.stateInfo!.nextStateAt).toBe(expectedNextStateAt);
-
     expect(target.character!.stateInfo!.state).toBe(CharacterStateType.BBANG_TARGET);
-    expect(target.character!.stateInfo!.stateTargetUserId).toBe(userId);
+    expect(user.character!.stateInfo!.nextStateAt).toBe(expectedNextStateAt);
     expect(target.character!.stateInfo!.nextStateAt).toBe(expectedNextStateAt);
-
     expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(2);
-    expect(mockRepeatDeck).toHaveBeenCalledWith(roomId, [CardType.BBANG]);
+    expect(mockRemoveCard).toHaveBeenCalledWith(user, mockRoom, CardType.BBANG);
   });
 
-  it('데스매치 상태에서 빵야를 사용하면, 데스매치 관련 상태로 변경해야 한다', () => {
+  it('데스매치 턴 상태에서 빵야를 사용하면 데스매치 관련 상태로 변경', () => {
     user.character!.stateInfo!.state = CharacterStateType.DEATH_MATCH_TURN_STATE;
 
     const result = cardBbangEffect(roomId, userId, targetId);
 
     expect(result).toBe(true);
     expect(user.character!.stateInfo!.state).toBe(CharacterStateType.DEATH_MATCH_STATE);
-    expect(user.character!.stateInfo!.nextState).toBe(CharacterStateType.DEATH_MATCH_TURN_STATE);
     expect(target.character!.stateInfo!.state).toBe(CharacterStateType.DEATH_MATCH_TURN_STATE);
-    expect(target.character!.stateInfo!.nextState).toBe(CharacterStateType.DEATH_MATCH_STATE);
     expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(2);
+    expect(mockRemoveCard).toHaveBeenCalledWith(user, mockRoom, CardType.BBANG);
   });
 
-  it('게릴라 타겟 상태에서 빵야를 사용하면, 상태를 초기화하고 GuerrillaService를 호출해야 한다', () => {
+  it('게릴라 타겟 상태에서 빵야를 사용하면 상태 초기화 & GuerrillaService 호출', () => {
     user.character!.stateInfo!.state = CharacterStateType.GUERRILLA_TARGET;
 
     const result = cardBbangEffect(roomId, userId, targetId);
@@ -132,36 +113,13 @@ describe('cardBbangEffect', () => {
     expect(result).toBe(true);
     expect(user.character!.stateInfo!.state).toBe(CharacterStateType.NONE_CHARACTER_STATE);
     expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, user.character);
-    expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(1); // Only user updated
-    expect(mockGetRoom).toHaveBeenCalledTimes(2); // Called again inside the logic
     expect(mockCheckGuerrillaService).toHaveBeenCalledWith(mockRoom);
-  });
-
-  // --- Card Handling Tests ---
-
-  it('카드 개수가 1개면 사용 후 handCards에서 제거해야 한다', () => {
-    user.character!.handCards = [{ type: CardType.BBANG, count: 1 }];
-
-    const result = cardBbangEffect(roomId, userId, targetId);
-
-    expect(result).toBe(true);
-    expect(user.character!.handCards.find(c => c.type === CardType.BBANG)).toBeUndefined();
-    expect(mockRepeatDeck).toHaveBeenCalledWith(roomId, [CardType.BBANG]);
-  });
-
-  it('카드 개수가 여러 장이면 사용 후 개수가 줄어야 한다', () => {
-    user.character!.handCards = [{ type: CardType.BBANG, count: 3 }];
-
-    const result = cardBbangEffect(roomId, userId, targetId);
-
-    expect(result).toBe(true);
-    expect(user.character!.handCards[0].count).toBe(2);
-    expect(mockRepeatDeck).toHaveBeenCalledWith(roomId, [CardType.BBANG]);
+    expect(mockRemoveCard).toHaveBeenCalledWith(user, mockRoom, CardType.BBANG);
   });
 
   // --- Error Handling Test ---
 
-  it('DB 업데이트 중 에러가 발생하면 false를 반환해야 한다', () => {
+  it('DB 업데이트 실패하면 false 반환', () => {
     const dbError = new Error('DB connection failed');
     mockUpdateCharacterFromRoom.mockImplementation(() => {
       throw dbError;
@@ -170,6 +128,6 @@ describe('cardBbangEffect', () => {
     const result = cardBbangEffect(roomId, userId, targetId);
 
     expect(result).toBe(false);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(`로그 저장에 실패하였습니다:[${dbError}]`);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(`[BBANG]로그 저장에 실패하였습니다:[${dbError}]`);
   });
 });

--- a/game.server/src/card/test/card.bbang.effect.test.ts
+++ b/game.server/src/card/test/card.bbang.effect.test.ts
@@ -1,135 +1,175 @@
-import { CharacterStateType, RoomStateType } from '../../generated/common/enums';
+import { CharacterStateType, RoomStateType, CardType } from '../../generated/common/enums';
 import { Room } from '../../models/room.model';
 import { User } from '../../models/user.model';
 import { CheckGuerrillaService } from '../../services/guerrilla.check.service';
 import { getRoom, getUserFromRoom, updateCharacterFromRoom } from '../../utils/room.utils';
+import { repeatDeck } from '../../managers/card.manager';
 import cardBbangEffect from '../card.bbang.effect';
 
 // Mock dependencies
 jest.mock('../../utils/room.utils');
 jest.mock('../../services/guerrilla.check.service');
+jest.mock('../../managers/card.manager');
 
-// Cast mocks to the correct type
+// Cast mocks to correct types
 const mockGetRoom = getRoom as jest.Mock;
 const mockGetUserFromRoom = getUserFromRoom as jest.Mock;
 const mockUpdateCharacterFromRoom = updateCharacterFromRoom as jest.Mock;
 const mockCheckGuerrillaService = CheckGuerrillaService as jest.Mock;
+const mockRepeatDeck = repeatDeck as jest.Mock;
 
 describe('cardBbangEffect', () => {
-	let mockRoom: Room;
-	let user: User;
-	let target: User;
-	const roomId = 1;
-	const userId = 'user-1';
-	const targetId = 'target-1';
-	let consoleLogSpy: jest.SpyInstance;
-	let consoleErrorSpy: jest.SpyInstance;
+  let mockRoom: Room;
+  let user: User;
+  let target: User;
+  const roomId = 1;
+  const userId = 'user-1';
+  const targetId = 'target-1';
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
 
-	beforeEach(() => {
-		jest.clearAllMocks();
+  beforeEach(() => {
+    jest.clearAllMocks();
 
-		const now = Date.now();
-		jest.spyOn(Date, 'now').mockReturnValue(now);
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now);
 
-		consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-		consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-		user = new User(userId, 'User');
-		user.character = { hp: 4, stateInfo: { state: CharacterStateType.NONE_CHARACTER_STATE } } as any;
+    user = new User(userId, 'User');
+    user.character = {
+      hp: 4,
+      stateInfo: { state: CharacterStateType.NONE_CHARACTER_STATE },
+      handCards: [{ type: CardType.BBANG, count: 1 }],
+    } as any;
 
-		target = new User(targetId, 'Target');
-		target.character = { hp: 4, stateInfo: { state: CharacterStateType.NONE_CHARACTER_STATE } } as any;
+    target = new User(targetId, 'Target');
+    target.character = {
+      hp: 4,
+      stateInfo: { state: CharacterStateType.NONE_CHARACTER_STATE },
+    } as any;
 
-		mockRoom = new Room(roomId, userId, 'Test Room', 8, RoomStateType.INGAME, [
-			user,
-			target,
-		]);
+    mockRoom = new Room(roomId, userId, 'Test Room', 8, RoomStateType.INGAME, [user, target]);
 
-		mockGetRoom.mockReturnValue(mockRoom);
-		mockGetUserFromRoom.mockImplementation((_, id) => (id === userId ? user : target));
-	});
+    mockGetRoom.mockReturnValue(mockRoom);
+    mockGetUserFromRoom.mockImplementation((_, id) => (id === userId ? user : target));
+  });
 
-	afterEach(() => {
-		consoleLogSpy.mockRestore();
-		consoleErrorSpy.mockRestore();
-	});
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
 
-	// --- Validation Tests ---
+  // --- Validation Tests ---
 
-	it('방, 유저, 타겟 정보가 없으면 false를 반환해야 한다', () => {
-		mockGetRoom.mockReturnValueOnce(null);
-		expect(cardBbangEffect(roomId, userId, targetId)).toBe(false);
+  it('방, 유저, 타겟 정보가 없으면 false를 반환해야 한다', () => {
+    mockGetRoom.mockReturnValueOnce(null);
+    expect(cardBbangEffect(roomId, userId, targetId)).toBe(false);
 
-		mockGetUserFromRoom.mockImplementationOnce(() => null);
-		expect(cardBbangEffect(roomId, userId, targetId)).toBe(false);
+    mockGetUserFromRoom.mockImplementationOnce(() => null);
+    expect(cardBbangEffect(roomId, userId, targetId)).toBe(false);
 
-		user.character = undefined;
-		expect(cardBbangEffect(roomId, userId, targetId)).toBe(false);
-	});
+    user.character = undefined;
+    expect(cardBbangEffect(roomId, userId, targetId)).toBe(false);
+  });
 
-	it('타겟의 HP가 0 이하면 false를 반환해야 한다', () => {
-		target.character!.hp = 0;
-		expect(cardBbangEffect(roomId, userId, targetId)).toBe(false);
-		expect(consoleLogSpy).toHaveBeenCalledWith('타깃 유저의 체력이 이미 0 입니다.');
-	});
+  it('타겟의 HP가 0 이하면 false를 반환해야 한다', () => {
+    target.character!.hp = 0;
+    expect(cardBbangEffect(roomId, userId, targetId)).toBe(false);
+    expect(consoleLogSpy).toHaveBeenCalledWith('타깃 유저의 체력이 이미 0 입니다.');
+  });
 
-	// --- State-based Logic Tests ---
+  it('카드를 소유하지 않으면 false를 반환해야 한다', () => {
+    user.character!.handCards = [];
+    const result = cardBbangEffect(roomId, userId, targetId);
+    expect(result).toBe(false);
+    expect(consoleWarnSpy).toHaveBeenCalledWith('[CardType:BBANG] 해당 카드를 소유하고 있지 않습니다');
+  });
 
-	it('일반 상태에서 빵야를 사용하면, BBANG 상태로 변경해야 한다', () => {
-		const now = Date.now();
-		const expectedNextStateAt = `${now + 10000}`;
+  // --- State-based Logic Tests ---
 
-		const result = cardBbangEffect(roomId, userId, targetId);
+  it('일반 상태에서 빵야를 사용하면, BBANG 상태로 변경해야 한다', () => {
+    const now = Date.now();
+    const expectedNextStateAt = `${now + 10000}`;
 
-		expect(result).toBe(true);
-		expect(user.character!.stateInfo!.state).toBe(CharacterStateType.BBANG_SHOOTER);
-		expect(user.character!.stateInfo!.stateTargetUserId).toBe(targetId);
-		expect(user.character!.stateInfo!.nextStateAt).toBe(expectedNextStateAt);
+    const result = cardBbangEffect(roomId, userId, targetId);
 
-		expect(target.character!.stateInfo!.state).toBe(CharacterStateType.BBANG_TARGET);
-		expect(target.character!.stateInfo!.stateTargetUserId).toBe(userId);
-		expect(target.character!.stateInfo!.nextStateAt).toBe(expectedNextStateAt);
+    expect(result).toBe(true);
+    expect(user.character!.stateInfo!.state).toBe(CharacterStateType.BBANG_SHOOTER);
+    expect(user.character!.stateInfo!.stateTargetUserId).toBe(targetId);
+    expect(user.character!.stateInfo!.nextStateAt).toBe(expectedNextStateAt);
 
-		expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(2);
-	});
+    expect(target.character!.stateInfo!.state).toBe(CharacterStateType.BBANG_TARGET);
+    expect(target.character!.stateInfo!.stateTargetUserId).toBe(userId);
+    expect(target.character!.stateInfo!.nextStateAt).toBe(expectedNextStateAt);
 
-	it('데스매치 상태에서 빵야를 사용하면, 데스매치 관련 상태로 변경해야 한다', () => {
-		user.character!.stateInfo!.state = CharacterStateType.DEATH_MATCH_TURN_STATE;
+    expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(2);
+    expect(mockRepeatDeck).toHaveBeenCalledWith(roomId, [CardType.BBANG]);
+  });
 
-		const result = cardBbangEffect(roomId, userId, targetId);
+  it('데스매치 상태에서 빵야를 사용하면, 데스매치 관련 상태로 변경해야 한다', () => {
+    user.character!.stateInfo!.state = CharacterStateType.DEATH_MATCH_TURN_STATE;
 
-		expect(result).toBe(true);
-		expect(user.character!.stateInfo!.state).toBe(CharacterStateType.DEATH_MATCH_STATE);
-		expect(user.character!.stateInfo!.nextState).toBe(CharacterStateType.DEATH_MATCH_TURN_STATE);
-		expect(target.character!.stateInfo!.state).toBe(CharacterStateType.DEATH_MATCH_TURN_STATE);
-		expect(target.character!.stateInfo!.nextState).toBe(CharacterStateType.DEATH_MATCH_STATE);
-		expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(2);
-	});
+    const result = cardBbangEffect(roomId, userId, targetId);
 
-	it('게릴라 타겟 상태에서 빵야를 사용하면, 상태를 초기화하고 GuerrillaService를 호출해야 한다', () => {
-		user.character!.stateInfo!.state = CharacterStateType.GUERRILLA_TARGET;
+    expect(result).toBe(true);
+    expect(user.character!.stateInfo!.state).toBe(CharacterStateType.DEATH_MATCH_STATE);
+    expect(user.character!.stateInfo!.nextState).toBe(CharacterStateType.DEATH_MATCH_TURN_STATE);
+    expect(target.character!.stateInfo!.state).toBe(CharacterStateType.DEATH_MATCH_TURN_STATE);
+    expect(target.character!.stateInfo!.nextState).toBe(CharacterStateType.DEATH_MATCH_STATE);
+    expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(2);
+  });
 
-		const result = cardBbangEffect(roomId, userId, targetId);
+  it('게릴라 타겟 상태에서 빵야를 사용하면, 상태를 초기화하고 GuerrillaService를 호출해야 한다', () => {
+    user.character!.stateInfo!.state = CharacterStateType.GUERRILLA_TARGET;
 
-		expect(result).toBe(true);
-		expect(user.character!.stateInfo!.state).toBe(CharacterStateType.NONE_CHARACTER_STATE);
-		expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, user.character);
-		expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(1); // Only user is updated
-		expect(mockGetRoom).toHaveBeenCalledTimes(2); // Called again inside the logic
-		expect(mockCheckGuerrillaService).toHaveBeenCalledWith(mockRoom);
-	});
+    const result = cardBbangEffect(roomId, userId, targetId);
 
-	// --- Error Handling Test ---
+    expect(result).toBe(true);
+    expect(user.character!.stateInfo!.state).toBe(CharacterStateType.NONE_CHARACTER_STATE);
+    expect(mockUpdateCharacterFromRoom).toHaveBeenCalledWith(roomId, userId, user.character);
+    expect(mockUpdateCharacterFromRoom).toHaveBeenCalledTimes(1); // Only user updated
+    expect(mockGetRoom).toHaveBeenCalledTimes(2); // Called again inside the logic
+    expect(mockCheckGuerrillaService).toHaveBeenCalledWith(mockRoom);
+  });
 
-	it('DB 업데이트 중 에러가 발생하면 false를 반환해야 한다', () => {
-		const dbError = new Error('DB connection failed');
-		mockUpdateCharacterFromRoom.mockImplementation(() => {
-			throw dbError;
-		});
+  // --- Card Handling Tests ---
 
-		const result = cardBbangEffect(roomId, userId, targetId);
+  it('카드 개수가 1개면 사용 후 handCards에서 제거해야 한다', () => {
+    user.character!.handCards = [{ type: CardType.BBANG, count: 1 }];
 
-		expect(result).toBe(false);
-		expect(consoleErrorSpy).toHaveBeenCalledWith(`로그 저장에 실패하였습니다:[${dbError}]`);
-	});
+    const result = cardBbangEffect(roomId, userId, targetId);
+
+    expect(result).toBe(true);
+    expect(user.character!.handCards.find(c => c.type === CardType.BBANG)).toBeUndefined();
+    expect(mockRepeatDeck).toHaveBeenCalledWith(roomId, [CardType.BBANG]);
+  });
+
+  it('카드 개수가 여러 장이면 사용 후 개수가 줄어야 한다', () => {
+    user.character!.handCards = [{ type: CardType.BBANG, count: 3 }];
+
+    const result = cardBbangEffect(roomId, userId, targetId);
+
+    expect(result).toBe(true);
+    expect(user.character!.handCards[0].count).toBe(2);
+    expect(mockRepeatDeck).toHaveBeenCalledWith(roomId, [CardType.BBANG]);
+  });
+
+  // --- Error Handling Test ---
+
+  it('DB 업데이트 중 에러가 발생하면 false를 반환해야 한다', () => {
+    const dbError = new Error('DB connection failed');
+    mockUpdateCharacterFromRoom.mockImplementation(() => {
+      throw dbError;
+    });
+
+    const result = cardBbangEffect(roomId, userId, targetId);
+
+    expect(result).toBe(false);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(`로그 저장에 실패하였습니다:[${dbError}]`);
+  });
 });


### PR DESCRIPTION
# 카드효과 로직에 카드 제거하는 코드 삭제 및 해당 모듈 호출로 변경
## 내용
- 카드효과 로직에 카드 제거하는 코드 삭제 및 해당 모듈 호출로 변경
- BBANG 테스트 코드 수정
- log문 및 주석 수정
### 테스트 내용 
     cardBbangEffect
    - 방이 없으면 false 반환 -> 통과
    - 유저 정보가 없으면 false 반환 -> 통과
    - 타겟 HP가 0 이하면 false 반환 -> 통과
    - 일반 상태에서 빵야를 사용하면 BBANG 상태로 변경 -> 통과
    - 데스매치 턴 상태에서 빵야를 사용하면 데스매치 관련 상태로 변경 -> 통과
    - 게릴라 타겟 상태에서 빵야를 사용하면 상태 초기화 & GuerrillaService 호출 -> 통과
    - DB 업데이트 실패하면 false 반환 -> 통과