### PR TITLE
Refactor/socket buffer simplify

### DIFF
--- a/game.server/src/sockets/on.end.ts
+++ b/game.server/src/sockets/on.end.ts
@@ -2,7 +2,12 @@ import { handleError } from '../handlers/handleError.js';
 import { removeSocket } from '../managers/socket.manger.js';
 import { GameSocket } from '../type/game.socket.js';
 import { removeTokenUserDB } from '../services/prisma.service.js';
-import { deleteRoom, getRoom, removeUserFromRoom } from '../utils/room.utils.js';
+import { deleteRoom, getRoom, removeUserFromRoom, saveRoom } from '../utils/room.utils.js';
+import { checkAndEndGameIfNeeded } from '../utils/game.end.util.js';
+import { broadcastDataToRoom } from '../utils/notification.util.js';
+import { GamePacketType } from '../enums/gamePacketType.js';
+import { createUserUpdateNotificationPacket } from '../useCase/use.card/use.card.usecase.js';
+import { RoomStateType } from '../generated/common/enums.js';
 
 
 const onEnd = (socket: GameSocket) => async () => {
@@ -15,12 +20,35 @@ const onEnd = (socket: GameSocket) => async () => {
 		}
 
 		if (socket.roomId) {
-			
-			// await removeUserFromRoom();
-			removeUserFromRoom(Number(socket.roomId), socket.userId!);
 			const room = getRoom(Number(socket.roomId));
-			if (room!.users.length <= 0) {
-				deleteRoom(Number(socket.roomId));
+			if (room) {
+				// 게임 중인 경우 플레이어를 죽은 상태로 처리
+				if (room.state === RoomStateType.INGAME) {
+					const disconnectedUser = room.users.find(user => user.id === socket.userId);
+					if (disconnectedUser && disconnectedUser.character && disconnectedUser.character.hp > 0) {
+												
+						// 플레이어 HP를 0으로 설정하여 죽은 상태로 처리
+						disconnectedUser.character.hp = 0;
+						
+						// 방 상태 저장
+						saveRoom(room);
+						
+						// 모든 플레이어에게 사용자 상태 업데이트 알림 전송
+						const userUpdatePacket = createUserUpdateNotificationPacket(room.users);
+						await broadcastDataToRoom(room.users, userUpdatePacket, GamePacketType.userUpdateNotification);
+						
+						// 게임 종료 조건 확인
+						await checkAndEndGameIfNeeded(Number(socket.roomId));
+					}
+				}
+				
+				// 기존 로직: 방에서 사용자 제거
+				removeUserFromRoom(Number(socket.roomId), socket.userId!);
+				
+				// 방에 사용자가 없으면 방 삭제
+				if (room.users.length <= 0) {
+					deleteRoom(Number(socket.roomId));
+				}
 			}
 		}
 	} catch (error) {


### PR DESCRIPTION
## 제목
refactor: 소켓 버퍼 관리 방식 개선 및 연결 끊어짐 시 플레이어 죽음 처리 추가


## 내용

### 변경 사항

#### 1. 소켓 버퍼 관리 방식 개선 (`on.data.ts`)
- **기존 방식**: `WeakMap`을 사용한 버퍼 관리
- **개선 방식**: `ExtendedSocket` 인터페이스로 소켓 객체에 직접 버퍼 저장
- **변경 내용**:
  ```typescript
  // 기존 (WeakMap 방식)
  const socketBuffers = new WeakMap<Socket, Buffer>();
  
  // 개선 (소켓 객체 직접 저장)
  interface ExtendedSocket extends Socket {
      buffer?: Buffer;
  }
  const extendedSocket = socket as ExtendedSocket;
  let buffer = extendedSocket.buffer || Buffer.alloc(0);
  ```

#### 2. 연결 끊어짐 시 플레이어 죽음 처리 (`on.end.ts`)
- **기능**: 게임 중 플레이어 연결이 끊어지면 자동으로 죽은 상태로 처리
- **구현 내용**:
  - 게임 중인 상태(`RoomStateType.INGAME`) 확인
  - 연결이 끊어진 플레이어의 HP를 0으로 설정
  - 모든 플레이어에게 사용자 상태 업데이트 알림 전송
  - 게임 종료 조건 자동 확인