### PR TITLE
🐛 fix:'removeCard 복구'

### DIFF
--- a/game.server/src/card/active/card.bbang.effect.ts
+++ b/game.server/src/card/active/card.bbang.effect.ts
@@ -4,6 +4,7 @@ import { CheckGuerrillaService } from '../../services/guerrilla.check.service';
 import { Room } from '../../models/room.model';
 import { User } from '../../models/user.model';
 import roomManger from '../../managers/room.manager';
+import { cardManager } from '../../managers/card.manager';
 
 const cardBbangEffect = (room: Room, user: User, target: User): boolean => {
 	// 정보값 가져오기
@@ -34,6 +35,7 @@ const cardBbangEffect = (room: Room, user: User, target: User): boolean => {
 		return false;
 	}
 
+	cardManager.removeCard(user, room, CardType.BBANG);
 	if (user.character.stateInfo.state === CharacterStateType.NONE_CHARACTER_STATE) {
 		// 상태 설정
 		user.character.stateInfo.state = CharacterStateType.BBANG_SHOOTER; // 빵야 카드 사용자는 BBANG_SHOOTER 상태가 되고

--- a/game.server/src/card/active/card.death_match.effect.ts
+++ b/game.server/src/card/active/card.death_match.effect.ts
@@ -2,6 +2,7 @@
 import { CardType, CharacterStateType } from '../../generated/common/enums';
 import { Room } from '../../models/room.model';
 import { User } from '../../models/user.model';
+import { cardManager } from '../../managers/card.manager';
 
 const DEATH_MATCH_DURATION_MS = 10;
 
@@ -22,7 +23,7 @@ const cardDeathMatchEffect = (room: Room, user: User, targetUser: User): boolean
 		return false;
 	}
 
-
+	cardManager.removeCard(user, room, CardType.BIG_BBANG);
 	if (user.character && targetUser.character) {
 		user.character.stateInfo = {
 			state: CharacterStateType.DEATH_MATCH_TURN_STATE,

--- a/game.server/src/card/active/card.matured_savings.effect.ts
+++ b/game.server/src/card/active/card.matured_savings.effect.ts
@@ -15,6 +15,7 @@ const cardMaturedSavingsEffect = (room: Room, user: User): boolean => {
 		return false;
 	}
 
+	cardManager.removeCard(user, room, CardType.MATURED_SAVINGS);
 	// 뽑을 카드 매수
 	const numberOfDraw = 2;
 	// 덱에 남은 카드 매수

--- a/game.server/src/card/debuff/card.bomb.effect.ts
+++ b/game.server/src/card/debuff/card.bomb.effect.ts
@@ -9,6 +9,7 @@ import { checkAndEndGameIfNeeded } from '../../services/game.end.service';
 import { Room } from '../../models/room.model';
 import { User } from '../../models/user.model';
 import { bombManager } from '../../services/bomb.service';
+import { cardManager } from '../../managers/card.manager';
 
 /** 폭탄 디버프 부여 */
 const cardBombEffect = (room: Room, user: User, target: User): boolean => {
@@ -26,6 +27,7 @@ const cardBombEffect = (room: Room, user: User, target: User): boolean => {
 		return false;
 	}
 
+	cardManager.removeCard(user, room, CardType.BOMB);
 	// 이미 해당 디버프 상태일 경우 ; 중복 검증
 	if (target.character.debuffs.includes(CardType.BOMB)) {
 		console.error(`[BOMB]이미 ${target.nickname} 유저는 폭탄을 보유중입니다.`);

--- a/game.server/src/card/debuff/card.containment_unit.effect.ts
+++ b/game.server/src/card/debuff/card.containment_unit.effect.ts
@@ -1,7 +1,7 @@
 // cardType = 21
 import { CardType, CharacterStateType } from '../../generated/common/enums';
 import roomManger from '../../managers/room.manager';
-//import { cardManager } from '../../managers/card.manager';
+import { cardManager } from '../../managers/card.manager';
 import { Room } from '../../models/room.model';
 import { User } from '../../models/user.model';
 
@@ -27,6 +27,7 @@ const cardContainmentUnitEffect = (room: Room, user: User, target: User): boolea
 		return false;
 	}
 
+	cardManager.removeCard(user, room, CardType.CONTAINMENT_UNIT);
 	target.character.debuffs.push(CardType.CONTAINMENT_UNIT);
 
 	return true;

--- a/game.server/src/card/equip/card.laser_pointer.effect.ts
+++ b/game.server/src/card/equip/card.laser_pointer.effect.ts
@@ -2,6 +2,7 @@
 import { CardType } from '../../generated/common/enums';
 import { Room } from '../../models/room.model';
 import { User } from '../../models/user.model';
+import { cardManager } from '../../managers/card.manager';
 
 const cardLaserPointerEffect = (room: Room, user: User): boolean => {
 	// 유효성 검증
@@ -15,6 +16,7 @@ const cardLaserPointerEffect = (room: Room, user: User): boolean => {
 	}
 
 	if (!user.character.equips.includes(CardType.LASER_POINTER)) {
+		cardManager.removeCard(user, room, CardType.LASER_POINTER);
 		user.character.equips.push(CardType.LASER_POINTER);
 	} else {
 		// 중복 착용 중일 경우

--- a/game.server/src/card/weapon/card.auto_rifle.effect.ts
+++ b/game.server/src/card/weapon/card.auto_rifle.effect.ts
@@ -2,6 +2,7 @@
 import { CardType } from '../../generated/common/enums';
 import { Room } from '../../models/room.model';
 import { User } from '../../models/user.model';
+import { cardManager } from '../../managers/card.manager';
 
 const cardAutoRifleEffect = (room: Room, user: User): boolean => {
 	// 유효성 검증
@@ -15,6 +16,7 @@ const cardAutoRifleEffect = (room: Room, user: User): boolean => {
 	}
 
 	if (user.character.weapon !== CardType.AUTO_RIFLE) {
+		cardManager.removeCard(user, room, CardType.AUTO_RIFLE);
 		user.character.weapon = CardType.AUTO_RIFLE;
 	} else {
 		return false;

--- a/game.server/src/dispatcher/apply.card.dispacher.ts
+++ b/game.server/src/dispatcher/apply.card.dispacher.ts
@@ -33,7 +33,6 @@ export function applyCardEffect(
 	targetUser: User,
 ): boolean {
 
-	cardManager.removeCard(user, room, CardType);
 	// 소지한 카드 제거 후 효과 적용
 	switch (CardType) {
 		case 1: //'BBANG':


### PR DESCRIPTION
# removeCard 복구
## 내용
- removeCard 로직 을 각 카드에서 처리하도록 복구
  - BBANG
  - DEATH_MATCH
  - MATURED_SAVINGS
  - AUTO_RIFLE
  - LASER_POINTER
  - CONTAINMENT_UNIT
  - BOMB
