### PR TITLE
🐛 fix: '죽은 플레이어를 제외한 카드 처리 및 반환 로직 수정'

### DIFF
--- a/game.server/src/card/class/card.flea.market.ts
+++ b/game.server/src/card/class/card.flea.market.ts
@@ -22,8 +22,9 @@ export class FleaMarketCard implements ICard {
 			0,
 		);
 
-		// 방 수 만큼 카드 드로우
-		const selectedCards = room.drawDeck(users.length - prisonCount);
+		// 살아있는 플레이어 수만큼 카드 드로우 (죽은 플레이어 제외)
+		const aliveUsersCount = users.filter(u => u.character && u.character.hp > 0).length;
+		const selectedCards = room.drawDeck(aliveUsersCount - prisonCount);
 		if (!selectedCards || !room.roomFleaMarketCards || !room.fleaMarketPickIndex) return false;
 		room.roomFleaMarketCards.push(...selectedCards);
 
@@ -39,6 +40,9 @@ export class FleaMarketCard implements ICard {
 			const otherUser = room.users[i];
 
 			if (!otherUser.character || !otherUser.character.stateInfo) continue;
+
+			// 죽은 플레이어(HP <= 0) 제외
+			if (otherUser.character.hp <= 0) continue;
 
 			if (
 				otherUser.id === user.id ||

--- a/game.server/src/managers/game.manager.ts
+++ b/game.server/src/managers/game.manager.ts
@@ -89,9 +89,9 @@ class GameManager {
 
 				// room = (await containmentCard.checkContainmentUnitTarget(room.id)) || room;
 
-				// 2. 카드 처리
+				// 2. 카드 처리 (죽은 플레이어 제외)
 				for (let user of room.users) {
-					if (user.character != null) {
+					if (user.character != null && user.character.hp > 0) {
 						console.log(
 							`${user.nickname}의 상태1:${CharacterStateType[user.character!.stateInfo!.state]}`,
 						);

--- a/game.server/src/models/room.model.ts
+++ b/game.server/src/models/room.model.ts
@@ -140,6 +140,45 @@ export class Room {
 		if (this.roomDecks) this.roomDecks.push(...cards);
 	}
 
+	// 죽은 플레이어의 모든 카드를 월드덱으로 이동
+	public returnDeadPlayerCardsToDeck(user: User): void {
+		if (!user.character || user.character.hp > 0) return;
+
+		const cardsToReturn: CardType[] = [];
+
+		// 핸드 카드들 월드덱으로 이동
+		user.character.handCards.forEach((card) => {
+			for (let i = 0; i < card.count; i++) {
+				cardsToReturn.push(card.type);
+			}
+		});
+		user.character.handCards = [];
+		user.character.handCardsCount = 0;
+
+		// 장비 카드들 월드덱으로 이동
+		user.character.equips.forEach((cardType) => {
+			cardsToReturn.push(cardType);
+		});
+		user.character.equips = [];
+
+		// 디버프 카드들 월드덱으로 이동
+		user.character.debuffs.forEach((cardType) => {
+			cardsToReturn.push(cardType);
+		});
+		user.character.debuffs = [];
+
+		// 무기 카드 월드덱으로 이동
+		if (user.character.weapon !== CardType.NONE) {
+			cardsToReturn.push(user.character.weapon);
+			user.character.weapon = CardType.NONE;
+		}
+
+		// 모든 카드를 월드덱에 추가
+		this.repeatDeck(cardsToReturn);
+
+		console.log(`[죽은 플레이어 카드 정리] ${user.nickname}: ${cardsToReturn.length}장의 카드를 월드덱으로 반환`);
+	}
+
 	public getDeckSize(): number {
 		if (this.roomDecks) return this.roomDecks.length;
 		else return 0;

--- a/game.server/src/services/take.damage.service.ts
+++ b/game.server/src/services/take.damage.service.ts
@@ -84,9 +84,8 @@ const takeDamageService = (room: Room, user: User, damage: number, shooter?: Use
 	if (user.character.hp <= 0) {
 		const maskMan = room.users.find((u) => u.character?.characterType === CharacterType.MASK);
 
-		if (maskMan) {
-			if (maskMan.character!.hp <= 0) return;
-
+		if (maskMan && maskMan.character!.hp > 0) {
+			// 마스크맨이 살아있으면 핸드 카드만 전달
 			if (user.character.handCardsCount > 0) {
 				for (let i = 0; i < user.character.handCards.length; i++) {
 					const card = user.character.handCards[i];
@@ -97,13 +96,11 @@ const takeDamageService = (room: Room, user: User, damage: number, shooter?: Use
 					}
 				}
 			}
+			// 장비, 디버프, 무기는 월드덱으로 반환
+			room.returnDeadPlayerCardsToDeck(user);
 		} else {
-			for (let i = 0; i < user.character.handCards.length; i++) {
-				const card = user.character.handCards[i];
-				for (let j = 0; j < card.count; j++) {
-					room.removeCard(user, card.type);
-				}
-			}
+			// 마스크맨이 없거나 죽었으면 모든 카드를 월드덱으로 반환
+			room.returnDeadPlayerCardsToDeck(user);
 		}
 	}
 };


### PR DESCRIPTION
- 플리마켓 카드 사용 시 HP <= 0인 플레이어 제외
- 플리마켓 턴 순서에서 죽은 플레이어 건너뛰기 로직 추가
- END 페이즈 카드 버리기 로직에서 죽은 플레이어 제외
- 플리마켓 카드 수를 살아있는 플레이어 수만큼만 표시
- 죽은 플레이어의 모든 카드(핸드/장비/디버프/무기)를 월드덱으로 반환
- 마스크맨 특수능력 고려하여 핸드카드는 전달, 나머지는 월드덱으로